### PR TITLE
feat(config): add config loader and remove wildcard config imports

### DIFF
--- a/src/static_fire_toolkit/config_loader.py
+++ b/src/static_fire_toolkit/config_loader.py
@@ -1,0 +1,100 @@
+"""Configuration loader for Static-Fire Toolkit runtime parameters.
+
+This module centralizes loading of global runtime parameters that were
+previously imported via wildcard imports. It prefers a user-provided
+``global_config.py`` file in the current working directory (the execution
+root), but falls back to safe defaults if none is found.
+
+Supported source (searched in the execution root):
+- global_config.py  (module with uppercase or lowercase attribute names)
+
+Future extension: TOML/YAML support can be added when a stable schema is
+finalized for non-code configuration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Config:
+    """Runtime configuration values used by processing modules."""
+
+    rated_output: float = 2.0  # mV/V or sensor unit (example default)
+    rated_load: float = 100.0  # kg or sensor unit (example default)
+    g: float = 9.80665
+    frequency: float = 100.0  # Hz (Δt = 0.01 s)
+    cutoff_frequency: float = 10.0  # Hz for LPF
+    lowpass_order: int = 2
+    gaussian_weak_sigma: float = 2.0
+    gaussian_strong_sigma: float = 8.0
+    start_criteria: float = 0.15
+    end_criteria: float = 0.15
+
+
+def _read_attr(cfg: Any, name: str, default: Any) -> Any:
+    # Accept both lowercase and uppercase attribute names
+    if hasattr(cfg, name):
+        return getattr(cfg, name)
+    upper = name.upper()
+    if hasattr(cfg, upper):
+        return getattr(cfg, upper)
+    return default
+
+
+def _load_from_python(path: Path, base: Config) -> Config:
+    spec = spec_from_file_location("user_global_config", path)
+    if spec and spec.loader:
+        mod = module_from_spec(spec)
+        spec.loader.exec_module(mod)  # type: ignore[reportAttributeAccessIssue]
+        return Config(
+            rated_output=float(_read_attr(mod, "rated_output", base.rated_output)),
+            rated_load=float(_read_attr(mod, "rated_load", base.rated_load)),
+            g=float(_read_attr(mod, "g", base.g)),
+            frequency=float(_read_attr(mod, "frequency", base.frequency)),
+            cutoff_frequency=float(
+                _read_attr(mod, "cutoff_frequency", base.cutoff_frequency)
+            ),
+            lowpass_order=int(_read_attr(mod, "lowpass_order", base.lowpass_order)),
+            gaussian_weak_sigma=float(
+                _read_attr(mod, "gaussian_weak_sigma", base.gaussian_weak_sigma)
+            ),
+            gaussian_strong_sigma=float(
+                _read_attr(mod, "gaussian_strong_sigma", base.gaussian_strong_sigma)
+            ),
+            start_criteria=float(
+                _read_attr(mod, "start_criteria", base.start_criteria)
+            ),
+            end_criteria=float(_read_attr(mod, "end_criteria", base.end_criteria)),
+        )
+    return base
+
+
+def load_global_config(execution_root: str | Path | None = None) -> Config:
+    """Load global runtime configuration from the execution root.
+
+    The search order currently supports only ``global_config.py``. If none is
+    found, a default :class:`Config` is returned.
+
+    Args:
+        execution_root: Directory to search. Defaults to current working dir.
+
+    Returns:
+        Config: Loaded configuration values.
+    """
+    root = Path(execution_root or ".").resolve()
+    defaults = Config()
+
+    py_cfg = root / "global_config.py"
+    if py_cfg.exists():
+        try:
+            return _load_from_python(py_cfg, defaults)
+        except Exception:
+            # Fall back to defaults if user config fails to load
+            return defaults
+
+    return defaults

--- a/src/static_fire_toolkit/post_process/pressure_post_processing.py
+++ b/src/static_fire_toolkit/post_process/pressure_post_processing.py
@@ -1,0 +1,604 @@
+"""Pressure Data Post Processing Code.
+
+2024.06.18
+First written by Jiwan Seo (Project Manager of Rocketry club Hanaro)
+E-mail: jiwan0216@snu.ac.kr
+
+2025.01.22. Updated by Yunseo Kim <yunseo@snu.ac.kr>:
+- Add the new DAQ's data format
+- Improve the interpolation algorithm from CubicSpline to PCHIP
+- Change output format from .txt(sep=' ') to .csv(sep=',')
+
+2025.02.08. Updated by Yunseo Kim <yunseo@snu.ac.kr>:
+- Added type hints and detailed docstrings
+- Improved error handling and logging throughout
+- Added data validation and warning messages
+
+2025.02.17. Updated by Yunseo Kim <yunseo@snu.ac.kr>:
+- To avoid file I/O errors based on the execution environment or current working directory,
+  set the file paths to absolute paths using the OS module
+- Encapsulate the logger within the class
+
+2025.03.06. Updated by Yunseo Kim <yunseo@snu.ac.kr>:
+- Improve the baseline estimation process
+- Add more detailed logging of peak detection for debugging
+- Add fallback width value(20) for too small peak widths (< 1.0)
+- Add logging of basic statistics (max, min, mean, std) for pressure raw data before processing
+- Add logging of maximum pressure value and its index after shifting
+"""
+
+import os
+import sys
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from scipy.interpolate import PchipInterpolator
+from scipy.signal import find_peaks, peak_widths
+from scipy.integrate import simpson
+import logging
+from static_fire_toolkit.config_loader import load_global_config
+
+# Add parent directory to Python path to import config
+sys.path.append(os.path.dirname(__file__))
+# Load global configuration from execution root
+_CFG = load_global_config()
+frequency = _CFG.frequency
+
+
+class PressurePostProcess:
+    """Pressure post-processing pipeline for static-fire data.
+
+    Handles interval estimation, interpolation to a uniform timestep, baseline
+    normalization, metrics, plotting, and CSV export. Synchronizes to thrust
+    data for consistent time windows.
+    """
+
+    def __init__(
+        self, pressure_data_raw: pd.DataFrame, thrust_data: pd.DataFrame, file_name: str
+    ) -> None:
+        """Initialize the PressurePostProcess object with raw pressure data and configuration parameters.
+
+        Args:
+            pressure_data_raw (pd.DataFrame): Raw data containing time and pressure measurements
+            thrust_data (pd.DataFrame): Processed thrust data for synchronization
+            file_name (str): File name identifier for logging and output
+
+        Raises:
+            ValueError: If input data is invalid or missing required columns
+        """
+        # Set up logging
+        self._logger = logging.getLogger(__name__)
+        self._BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+        log_dir = os.path.join(self._BASE_DIR, "logs")
+        os.makedirs(log_dir, exist_ok=True)
+        log_filename = os.path.join(log_dir, f"{file_name}-pressure_processing.log")
+
+        # Configure file handler
+        file_handler = logging.FileHandler(log_filename)
+        file_handler.setFormatter(
+            logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+        )
+
+        # Configure console handler
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+
+        # Set up logger
+        self._logger.setLevel(logging.INFO)
+        self._logger.addHandler(file_handler)
+        self._logger.addHandler(console_handler)
+
+        self._logger.info("0. Initializing PressurePostProcess object")
+
+        # Validate inputs
+        if not isinstance(pressure_data_raw, pd.DataFrame):
+            self._logger.error("pressure_data_raw must be a pandas DataFrame")
+            raise ValueError("pressure_data_raw must be a pandas DataFrame")
+
+        if not isinstance(thrust_data, pd.DataFrame):
+            self._logger.error("thrust_data must be a pandas DataFrame")
+            raise ValueError("thrust_data must be a pandas DataFrame")
+
+        if pressure_data_raw.empty or thrust_data.empty:
+            self._logger.error("Input DataFrames cannot be empty")
+            raise ValueError("Input DataFrames cannot be empty")
+
+        self._thrust_data = thrust_data
+        self._file_name = file_name
+
+        # Process raw pressure data
+        try:
+            self._data_raw = pressure_data_raw.iloc[:, [0, 2]].copy()
+            self._data_raw.columns = ["time", "pressure"]
+            self._data_raw["pressure"] = pd.to_numeric(
+                self._data_raw["pressure"], errors="coerce"
+            )
+
+            # Check for NaN values after conversion
+            if self._data_raw["pressure"].isna().any():
+                self._logger.warning(
+                    "Some pressure values could not be converted to numeric format"
+                )
+                # Clean NaN values by forward fill, then backward fill
+                self._data_raw["pressure"].fillna(method="ffill").fillna(
+                    method="bfill", inplace=True
+                )
+
+            self._logger.info("0. Successfully initialized pressure data processing")
+
+        except Exception as e:
+            self._logger.error(f"Error processing raw pressure data: {str(e)}")
+            raise
+
+    # Step 1-1
+    def _estimate_interval(self, data: pd.DataFrame) -> pd.DataFrame:
+        """Estimate the meaningful interval of pressure data based on peak detection.
+
+        Args:
+            data (pd.DataFrame): DataFrame containing 'time' and 'pressure' columns
+
+        Returns:
+            pd.DataFrame: Subset of data containing the estimated interval
+
+        Raises:
+            ValueError: If required columns are missing or peak detection fails
+        """
+        self._logger.info("   1-1. Estimating interval of pressure data")
+        try:
+            pressure_max = data["pressure"].max()  # maximum pressure
+            # peaks, _ = find_peaks(data['pressure'], height=pressure_max)
+            # (2025.03.06.) 피크 감지 개선: 초기 탐색에서는 상대적인 높이를 사용하고, 피크 인식 기준을 완화하여 더 많은 피크를 찾도록 함
+            # 이는 여러 개의 피크가 존재하는 데이터에 대해 보다 강건한(robust) 피크 탐색 및 유사시 수월한 디버깅을 가능하도록 하기 위함임.
+            pressure_min = data["pressure"].min()
+            # 피크 감지 기준 설정: 1 이상이면서, 최대 압력 피크의 0.5배 이상이어야 함
+            pressure_height = max(0.5 * (pressure_max - pressure_min), 1)
+
+            peaks, peak_properties = find_peaks(
+                data["pressure"], height=pressure_min + pressure_height, distance=5
+            )  # 최소 피크 간격
+
+            if len(peaks) == 0:
+                self._logger.error("   1-1. No peak detected in the pressure data")
+                raise ValueError("No peak detected in the pressure data")
+
+            # (2025.03.06.) 첫 번째 피크가 아닌 가장 높은 피크를 사용하도록 변경.
+            # 이는 여러 개의 피크가 존재하는 데이터에 대해 보다 강건한(robust) 피크 탐색 및 유사시 수월한 디버깅을 가능하도록 하기 위함임.
+            # peak_index = peaks[0]
+            peak_heights = peak_properties["peak_heights"]
+            max_peak_idx = np.argmax(peak_heights)
+            peak_index = peaks[max_peak_idx]
+
+            # 탐지한 피크 목록 및 최대 피크 기록
+            self._logger.info("   1-1. Detected %d peaks.", len(peaks))
+            for i, peak in enumerate(peaks):
+                self._logger.info(
+                    "      - Peak %d: index %d, height %.2f", i, peak, peak_heights[i]
+                )
+            self._logger.info(
+                "   1-1. Using highest peak at index %d with value %.2f",
+                peak_index,
+                data["pressure"].iloc[peak_index],
+            )
+
+            # 피크의 폭 계산
+            widths = peak_widths(data["pressure"], [peak_index], rel_height=0.5)
+            width_value = widths[0][0]
+            self._logger.info("   1-1. Detected peak width: %.2f", width_value)
+            if width_value == 0 or width_value < 1.0:
+                self._logger.warning(
+                    "   1-1. Detected peak width is very small: %.2f. Using fallback default width(20).",
+                    width_value,
+                )
+                width_value = 20.0  # 기본 너비 값 사용
+
+            # Calculate indices with bounds checking
+            # (2025.03.06.) 정확한 이유는 아직 불명이나, 추력 데이터 후처리 시의 구간 추정 폭과 다른 값을 사용할 경우 드물게 터무니없이 큰 압력 값을 출력하는 버그가 존재함.
+            # 추력 데이터 후처리 코드와 동일한 기준(앞으로 2 * width_value, 뒤로 6 * width_value)을 사용하거나, 혹은 아예 앞뒤로 충분히 큰 마진(예: 4 * width_value, 8 * width_value)을 둘 것을 권고함.
+            start_index = max(0, int(peak_index - 2 * width_value))
+            end_index = min(len(data), int(peak_index + 6 * width_value))
+
+            self._logger.info(
+                "       Estimated interval indices: start_index=%d, end_index=%d.",
+                start_index,
+                end_index,
+            )
+            interval_data = data[start_index:end_index].copy()
+
+            # Debug plotting of interval_data
+            """
+            import matplotlib.pyplot as plt
+            plt.figure()
+            plt.plot(interval_data['time'], interval_data['pressure'], marker='o', linestyle='-')
+            plt.title('Interval Data Plot')
+            plt.xlabel('Time (s)')
+            plt.ylabel('Pressure')
+            plt.show()
+            """
+
+            # Log time interval statistics.
+            dt = np.diff(interval_data["time"].values)
+            if np.any(dt <= 0):
+                self._logger.warning("   1-1. Time values are not strictly increasing")
+                # 중복된 시간값 처리: 그룹화 후 평균 계산
+                interval_data = (
+                    interval_data.groupby("time")["pressure"].mean().reset_index()
+                )
+                dt = np.diff(interval_data["time"].values)
+            self._logger.info(
+                "       Time interval statistics: min=%.6f, max=%.6f, mean=%.6f",
+                dt.min(),
+                dt.max(),
+                dt.mean(),
+            )
+
+            return interval_data
+
+        except Exception as e:
+            self._logger.error(
+                "  1-1. Error during interval estimation: %s", e, exc_info=True
+            )
+            raise
+
+    # Step 1-2: Change to an evenly-spaced data with spline interpolation
+    def _interpolate(self, data: pd.DataFrame) -> pd.DataFrame:
+        """Interpolate pressure data using PCHIP to uniform timesteps.
+
+        Args:
+            data (pd.DataFrame): DataFrame containing 'time' and 'pressure' columns
+
+        Returns:
+            pd.DataFrame: Interpolated data with evenly spaced time points
+
+        Raises:
+            ValueError: If required columns are missing or interpolation fails
+        """
+        self._logger.info("   1-2. Starting interpolation of pressure data.")
+        try:
+            time_interval = 1 / frequency
+
+            # PCHIP interpolation
+            spline_function = PchipInterpolator(data["time"], data["pressure"])
+            time_interpolated = np.arange(0, data["time"].max(), time_interval)
+            pressure_interpolated = spline_function(time_interpolated)
+            data_interpolated = pd.DataFrame(
+                {"time": time_interpolated, "pressure": pressure_interpolated}
+            )
+
+            self._logger.info(
+                "   1-2. Interpolation complete. Generated %d data points.",
+                len(data_interpolated),
+            )
+            return data_interpolated
+
+        except Exception as e:
+            self._logger.error(
+                "   1-2. Error during interpolation: %s", e, exc_info=True
+            )
+            raise
+
+    # Step 1
+    def _data_preset(self) -> None:
+        """Prepare raw pressure data by estimating interval and interpolating.
+
+        This method combines interval estimation and interpolation steps.
+
+        Raises:
+            ValueError: If data processing fails at any step
+        """
+        self._logger.info("1. Starting data preset process.")
+        try:
+            # 데이터 검증
+            if (
+                "time" not in self._data_raw.columns
+                or "pressure" not in self._data_raw.columns
+            ):
+                self._logger.error("1. Missing required columns in raw data")
+                raise ValueError(
+                    "Missing required columns 'time' or 'pressure' in raw data"
+                )
+
+            # 압력 raw 데이터 초기 통계 기록
+            pressure_stats = self._data_raw["pressure"].describe()
+            self._logger.info(
+                "1. Pressure data statistics: min=%.3f, max=%.3f, mean=%.3f, std=%.3f",
+                pressure_stats["min"],
+                pressure_stats["max"],
+                pressure_stats["mean"],
+                pressure_stats["std"],
+            )
+
+            try:
+                # Convert time strings to seconds more efficiently using vectorized operations
+                self._data_raw["time"] = pd.to_datetime(self._data_raw["time"])
+                data_time_zero = self._data_raw["time"].iloc[0]
+                self._data_raw["time"] = (
+                    self._data_raw["time"] - data_time_zero
+                ).dt.total_seconds()
+
+                # Round to microsecond precision to avoid floating point errors
+                self._data_raw["time"] = self._data_raw["time"].round(6)
+
+            except ValueError as e:
+                self._logger.error(f"1. Error parsing time format: {str(e)}")
+                raise
+
+            # 구간 추정 및 데이터 보간
+            data_interval = self._estimate_interval(self._data_raw)
+            data_interval = data_interval.reset_index(drop=True)
+
+            self._data = self._interpolate(data_interval)
+            self._logger.info("1. Data preset process complete.")
+
+        except Exception as e:
+            self._logger.error("1. Error during data preset: %s", e, exc_info=True)
+            raise
+
+    # Step 2: Select meaningful interval
+    def _find_interval(self) -> None:
+        """Select meaningful interval synchronized with thrust data.
+
+        This aligns pressure data with thrust data based on peak locations.
+
+        Raises:
+            ValueError: If synchronization fails
+        """
+        self._logger.info("2. Finding interval synchronized with thrust data")
+        try:
+            if "thrust" not in self._thrust_data.columns:
+                self._logger.error("2. Thrust data must contain 'thrust' column")
+                raise ValueError("Thrust data must contain 'thrust' column")
+
+            max_thrust_index = self._thrust_data["thrust"].idxmax()
+            increase_length = max_thrust_index
+            decrease_length = len(self._thrust_data["thrust"]) - max_thrust_index
+
+            max_pressure_index = self._data["pressure"].idxmax()
+
+            # Calculate indices with bounds checking
+            start_index = max(0, max_pressure_index - increase_length)
+            end_index = min(len(self._data), max_pressure_index + decrease_length)
+
+            self._data_cut = self._data[start_index:end_index].copy()
+            self._data_cut = self._data_cut.reset_index(drop=True)
+            self._data_cut["time"] -= self._data_cut["time"][0]
+
+            self._logger.info("2. Successfully synchronized intervals")
+
+        except Exception as e:
+            self._logger.error(f"2. Error in interval synchronization: {str(e)}")
+            raise
+
+    # Step 3: linear shifting from the start point to the end point
+    def _shift(self) -> None:
+        """Apply linear shift to normalize baseline pressure.
+
+        Calculates the difference between initial local pressure and standard
+        atmosphere (1.013 bar) and shifts the series accordingly.
+
+        Raises:
+            ValueError: If shifting operation fails.
+        """
+        self._logger.info("3. Starting pressure data shifting.")
+        try:
+            if self._data_raw.empty or self._data_cut.empty:
+                self._logger.error("Data not properly initialized for shifting")
+                raise ValueError("Data not properly initialized for shifting")
+
+            # shifted_value = self._data_raw['pressure'][0] - 1.013
+            # (2025.03.06.) 표준대기압으로 보정 시 처음 10개 데이터포인트의 평균을 사용하여 베이스라인 계산
+            # 이는 첫 번째 데이터 포인트에만 의존하는 것보다 더 안정적임
+            baseline_samples = min(10, len(self._data_raw))
+            baseline = self._data_raw["pressure"].iloc[:baseline_samples].mean()
+            shifted_value = baseline - 1.013
+
+            pressure_shifted = self._data_cut["pressure"] - shifted_value
+
+            self._data_shifted = pd.DataFrame(
+                {"time": self._data_cut["time"].copy(), "pressure": pressure_shifted}
+            )
+
+            self._max_pressure_index = self._data_shifted["pressure"].idxmax()
+            self._logger.info(
+                "3. Data shifting complete. (shift value: %.3f [bar])", -shifted_value
+            )
+
+            # 최대 압력 위치 기록
+            self._max_pressure_index = self._data_shifted["pressure"].idxmax()
+            max_pressure = self._data_shifted["pressure"].max()
+            self._logger.info(
+                f"3. Maximum pressure: {max_pressure:.2f} bar at index {self._max_pressure_index}"
+            )
+
+        except Exception as e:
+            self._logger.error(f"3. Error during shifting: {str(e)}")
+            raise
+
+    # Step 4
+    def _pressure_plot(self) -> None:
+        """Plot the shifted pressure data with annotations and save the plot as an image file."""
+        self._logger.info("4. Plotting pressure data.")
+        try:
+            # Calculate key metrics
+            pressure_integral = simpson(
+                self._data_shifted["pressure"], x=self._data_shifted["time"]
+            )
+            total_time = self._data_shifted["time"].max()
+            average_pressure = pressure_integral / total_time
+            max_pressure = self._data_shifted["pressure"].max()
+            max_pressure_time = self._data_shifted["time"][self._max_pressure_index]
+
+            # Create plot
+            fig, ax = plt.subplots(figsize=(16, 9))
+
+            # Plot main data
+            ax.plot(
+                self._data_shifted["time"],
+                self._data_shifted["pressure"],
+                color="black",
+                linewidth=2.5,
+                zorder=0,
+            )
+
+            # Add key points
+            x = [max_pressure_time, total_time]
+            y = [max_pressure, self._data_shifted["pressure"].iloc[-1]]
+            ax.scatter(x, y, marker="o", color="red", s=120, zorder=1)
+
+            # Set limits
+            ax.set_xlim([0, 1.11 * total_time])
+            ax.set_ylim([-0.05 * max_pressure, 1.12 * max_pressure])
+
+            # Add annotations
+            ax.annotate(
+                f"Max Pressure   {max_pressure:.2f} Bar",
+                xy=(max_pressure_time / total_time * 0.65, 0.94),
+                xycoords="axes fraction",
+                size=20,
+                font="Arial",
+            )
+
+            ax.annotate(
+                f"Total Time\n{total_time:.2f} s",
+                xy=(0.89, 0.12),
+                xycoords="axes fraction",
+                size=20,
+                font="Arial",
+            )
+
+            ax.annotate(
+                f"Average Pressure     {average_pressure:.2f} Bar",
+                xy=(0.67, 0.95),
+                xycoords="axes fraction",
+                size=20,
+                font="Arial",
+            )
+
+            # Set labels and title
+            ax.set_xlabel("Time [s]", size=20, font="Arial")
+            ax.xaxis.set_label_coords(0.5, -0.07)
+            ax.set_ylabel("Pressure [Bar]", size=20, font="Arial")
+            ax.yaxis.set_label_coords(-0.07, 0.5)
+
+            fig.suptitle(
+                f"{self._file_name} Pressure Graph",
+                y=0.95,
+                fontsize=25,
+                fontweight="bold",
+                font="Arial",
+            )
+
+            # Customize grid and ticks
+            ax.grid(True)
+            ax.tick_params(axis="both", which="major", labelsize=15)
+
+            # Save and display
+            save_path = os.path.join(
+                os.path.dirname(self._BASE_DIR),
+                "pressure_graph",
+                f"{self._file_name}_pressure.png",
+            )
+            os.makedirs(os.path.dirname(save_path), exist_ok=True)
+            plt.savefig(save_path, bbox_inches=None, pad_inches=0, dpi=500)
+            plt.show()
+
+            self._logger.info("4. Pressure plot saved to %s", save_path)
+
+        except Exception as e:
+            self._logger.error(
+                "4. Error during plotting pressure data: %s", e, exc_info=True
+            )
+            raise
+
+    # Step 5
+    def _data_save(self) -> None:
+        """Save processed pressure data to CSV file."""
+        self._logger.info("5. Saving processed pressure data")
+        try:
+            save_dir = os.path.join(
+                os.path.dirname(self._BASE_DIR), "pressure_post_process"
+            )
+            os.makedirs(save_dir, exist_ok=True)
+            save_path = os.path.join(save_dir, f"{self._file_name}_pressure.csv")
+
+            self._data_shifted.to_csv(save_path, index=False)
+            self._logger.info(f"5. Data saved successfully to {save_path}")
+
+        except Exception as e:
+            self._logger.error(f"5. Error saving data: {str(e)}")
+            raise
+
+    def run(self) -> pd.DataFrame:
+        """Run the full pressure data processing pipeline."""
+        self._logger.info("Starting pressure data processing pipeline.")
+        self._data_preset()
+        self._find_interval()
+        self._shift()
+        self._pressure_plot()
+        self._data_save()
+        self._logger.info("Pressure data processing pipeline complete.")
+        return self._data_shifted
+
+
+if __name__ == "__main__":
+    # Read config.xlsx
+    base_dir = os.path.dirname(__file__)
+    config_path = os.path.join(os.path.dirname(base_dir), "config.xlsx")
+    if not os.path.exists(config_path):
+        print(f"Configuration file not found: {config_path}")
+        raise FileNotFoundError(f"Configuration file not found: {config_path}")
+
+    config = pd.read_excel(config_path, sheet_name=0, header=0, index_col=0)
+    idx = len(config) - 1
+    expt_file_name = config["expt_file_name"][idx]
+    print(f"Loaded configuration for experiment: {expt_file_name}")
+
+    # Set up file paths
+    thrust_dir = os.path.join(os.path.dirname(base_dir), "thrust_post_process")
+    pressure_raw_dir = os.path.join(os.path.dirname(base_dir), "_pressure_raw")
+
+    # Define file paths
+    thrust_csv_path = os.path.join(thrust_dir, f"{expt_file_name}_thrust.csv")
+    thrust_txt_path = os.path.join(thrust_dir, f"{expt_file_name}_thrust.txt")
+    pressure_csv_path = os.path.join(
+        pressure_raw_dir, f"{expt_file_name}_pressure_raw.csv"
+    )
+    pressure_txt_path = os.path.join(
+        pressure_raw_dir, f"{expt_file_name}_pressure_raw.txt"
+    )
+
+    # Find pressure data file
+    if os.path.exists(pressure_csv_path):
+        pressure_data_file = pressure_csv_path
+        print(f"Using CSV pressure data file: {pressure_csv_path}")
+    elif os.path.exists(pressure_txt_path):
+        pressure_data_file = pressure_txt_path
+        print(f"Using TXT pressure data file: {pressure_txt_path}")
+    else:
+        error_msg = (
+            f"No pressure data file found at {pressure_csv_path} or {pressure_txt_path}"
+        )
+        print(error_msg)
+        raise FileNotFoundError(error_msg)
+
+    # Find thrust data file
+    if os.path.exists(thrust_csv_path):
+        thrust_data_file = thrust_csv_path
+        print(f"Using CSV thrust data file: {thrust_csv_path}")
+    elif os.path.exists(thrust_txt_path):
+        thrust_data_file = thrust_txt_path
+        print(f"Using TXT thrust data file: {thrust_txt_path}")
+    else:
+        error_msg = (
+            f"No thrust data file found at {thrust_csv_path} or {thrust_txt_path}"
+        )
+        print(error_msg)
+        raise FileNotFoundError(error_msg)
+
+    # Read and process data
+    pressure_data = pd.read_csv(pressure_data_file, sep=";", header=0)
+    thrust_data = pd.read_csv(thrust_data_file, sep="[, ]", header=0, engine="python")
+    print("Successfully loaded input data files.")
+
+    # Initialize processor and run processing steps
+    process = PressurePostProcess(pressure_data, thrust_data, expt_file_name)
+    _ = process.run()

--- a/src/static_fire_toolkit/post_process/thrust_post_processing.py
+++ b/src/static_fire_toolkit/post_process/thrust_post_processing.py
@@ -1,0 +1,712 @@
+"""Thrust Data Post Processing Code.
+
+2024.06.18
+First written by Jiwan Seo (Project Manager of Rocketry club Hanaro)
+E-mail: jiwan0216@snu.ac.kr
+
+2025.01.22. Updated by Yunseo Kim <yunseo@snu.ac.kr>:
+- Add the new DAQ's data format
+- Improve the interpolation algorithm from CubicSpline to PCHIP
+- Change output format from .txt(sep=' ') to .csv(sep=',')
+
+2025.02.08. Updated by Yunseo Kim <yunseo@snu.ac.kr>:
+- Added type hints and detailed docstrings
+- Improved error handling and logging throughout
+- Checks for duplicate or non-increasing timestamps and logs warnings
+- Added validations and guidance when key data are missing or invalid
+- Check and resolve the part where the deprecation warning occured
+
+2025.02.17. Updated by Yunseo Kim <yunseo@snu.ac.kr>:
+- To avoid file I/O errors based on the execution environment or current working directory,
+  set the file paths to absolute paths using the OS module
+- Encapsulate the logger within the class
+
+2025.03.06. Updated by Yunseo Kim <yunseo@snu.ac.kr>:
+- Add prevention of negative thrust values
+- Add logging of max thrust value and its index
+"""
+
+import os
+import sys
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from scipy.interpolate import PchipInterpolator
+from scipy.signal import find_peaks, peak_widths, butter, lfilter
+from scipy.ndimage import gaussian_filter1d
+from scipy.integrate import simpson
+import logging
+from static_fire_toolkit.config_loader import load_global_config
+
+# Add parent directory to Python path to import config (kept for backward compatibility of CLI entry)
+sys.path.append(os.path.dirname(__file__))
+
+# Load configuration parameters explicitly
+_CFG = load_global_config()
+rated_output = _CFG.rated_output
+rated_load = _CFG.rated_load
+g = _CFG.g
+frequency = _CFG.frequency
+cutoff_frequency = _CFG.cutoff_frequency
+lowpass_order = _CFG.lowpass_order
+gaussian_weak_sigma = _CFG.gaussian_weak_sigma
+gaussian_strong_sigma = _CFG.gaussian_strong_sigma
+start_criteria = _CFG.start_criteria
+end_criteria = _CFG.end_criteria
+
+
+class ThrustPostProcess:
+    """End-to-end thrust post-processing pipeline.
+
+    Responsibilities include raw input normalization, interval estimation,
+    interpolation to a uniform timestep, filtering, baseline correction,
+    metric extraction, plotting, and CSV export.
+    """
+
+    # Step 0. Initialize the object
+    def __init__(
+        self,
+        data_raw: pd.DataFrame,
+        file_name: str,
+        input_voltage: float,
+        resistance: float,
+    ) -> None:
+        """Initialize the ThrustPostProcess object with raw data and configuration parameters.
+
+        Args:
+            data_raw (pd.DataFrame): Raw data containing time and thrust measurements.
+            file_name (str): File name identifier.
+            input_voltage (float): Input voltage used during measurement.
+            resistance (float): Resistance value used during measurement.
+
+        Raises:
+            ValueError: If data_raw is not a pandas DataFrame, is empty, or has insufficient columns.
+        """
+        # Set up logging
+        self._logger = logging.getLogger(__name__)
+        self._BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+        log_dir = os.path.join(self._BASE_DIR, "logs")
+        os.makedirs(log_dir, exist_ok=True)
+        log_filename = os.path.join(log_dir, f"{file_name}-thrust_processing.log")
+
+        # Configure file handler
+        file_handler = logging.FileHandler(log_filename)
+        file_handler.setFormatter(
+            logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+        )
+
+        # Configure console handler
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+
+        # Set up logger
+        self._logger.setLevel(logging.INFO)
+        self._logger.addHandler(file_handler)
+        self._logger.addHandler(console_handler)
+
+        self._logger.info("0. Initializing ThrustPostProcess object.")
+        if not isinstance(data_raw, pd.DataFrame):
+            self._logger.error("data_raw must be a pandas DataFrame.")
+            raise ValueError("data_raw must be a pandas DataFrame.")
+
+        if data_raw.empty:
+            self._logger.error("Input data_raw DataFrame is empty.")
+            raise ValueError("Input data_raw DataFrame is empty.")
+
+        # 데이터 형태 확인
+        rows, cols = data_raw.shape
+        if cols > rows:  # 기존에 사용하던 구 형식: 호환을 위해 전치 필요
+            self._logger.info("   Legacy data format detected: Transpose data")
+            data_raw = data_raw.transpose()
+
+        if data_raw.shape[1] < 2:
+            self._logger.error(
+                "Input data must have at least two columns for time and thrust."
+            )
+            raise ValueError(
+                "Input data must have at least two columns for time and thrust."
+            )
+
+        self._data_raw: pd.DataFrame = data_raw.copy()
+        self._data_raw.columns = ["time", "thrust"]
+        self._file_name: str = file_name
+        self._input_voltage: float = input_voltage
+        self._resistance: float = resistance
+
+        self._logger.info("0. Initialization complete.")
+
+    def _gaussian_filter(self, data: pd.DataFrame, sigma: float) -> pd.DataFrame:
+        """Apply a Gaussian filter to the thrust data.
+
+        Args:
+            data (pd.DataFrame): DataFrame containing 'time' and 'thrust' columns.
+            sigma (float): Standard deviation for the Gaussian kernel.
+
+        Returns:
+            pd.DataFrame: DataFrame with the filtered thrust data.
+        """
+        self._logger.info("   Applying Gaussian filter with sigma=%s.", sigma)
+        try:
+            if sigma <= 0:
+                self._logger.error(
+                    f"   Invalid sigma value: {sigma}. Must be positive."
+                )
+                raise ValueError(f"Invalid sigma value: {sigma}. Must be positive.")
+
+            thrust_gaussian = gaussian_filter1d(data["thrust"], sigma)
+            data_gaussian = pd.DataFrame(
+                {"time": data["time"], "thrust": thrust_gaussian}
+            )
+            self._logger.info("   Gaussian filtering complete.")
+            return data_gaussian
+        except Exception as e:
+            self._logger.error("   Error in Gaussian filtering: %s", e, exc_info=True)
+            raise
+
+    # Step 1-1
+    def _convert_voltage_to_thrust(self, data: pd.DataFrame) -> pd.DataFrame:
+        """Convert voltage to thrust using the provided formula.
+
+        Args:
+            data (pd.DataFrame): DataFrame containing 'time' and 'thrust' columns.
+
+        Returns:
+            pd.DataFrame: DataFrame with the converted thrust values.
+        """
+        self._logger.info("   1-1. Converting voltage to thrust.")
+        try:
+            # 전압 값을 추력으로 변환
+            data["thrust"] = (
+                data["thrust"]
+                * 1000
+                / (rated_output * self._input_voltage)
+                * rated_load
+                * g
+                / (1 + 49.4 * 1000 / self._resistance)
+            )
+        except Exception as e:
+            self._logger.error("Error converting voltage to thrust: %s", e)
+            raise
+
+        # 추력 데이터 부호 확인 후 필요하다면 반전
+        if abs(data["thrust"].min()) > abs(data["thrust"].max()):
+            self._logger.info(
+                "   Inverting thrust values to maintain correct polarity."
+            )
+            data["thrust"] *= -1
+
+        self._logger.info("   1-1. Voltage to thrust conversion complete.")
+        return data
+
+    # Step 1-2
+    def _estimate_interval(self, data: pd.DataFrame) -> pd.DataFrame:
+        """Estimate meaningful thrust interval by detecting the thrust peak.
+
+        Uses a strong Gaussian filter to smooth the data, then identifies the peak and its width to define
+        the start and end indices for the interval.
+
+        Args:
+            data (pd.DataFrame): DataFrame with 'time' and 'thrust' columns.
+
+        Returns:
+            pd.DataFrame: DataFrame cropped to the estimated interval.
+
+        Raises:
+            ValueError: If no peak is detected or if the detected peak width is zero.
+        """
+        self._logger.info("   1-2. Estimating interval of thrust data.")
+        try:
+            # Apply strong Gaussian filtering for smoothing.
+            strong_filtered = self._gaussian_filter(data, gaussian_strong_sigma)
+            thrust_max = strong_filtered["thrust"].max()
+            peaks, _ = find_peaks(strong_filtered["thrust"], height=thrust_max)
+            if len(peaks) == 0:
+                self._logger.error("   1-2. No peak detected in the thrust data.")
+                raise ValueError("No peak detected in the thrust data.")
+
+            # Use the first detected peak.
+            peak_index = peaks[0]
+            widths = peak_widths(strong_filtered["thrust"], peaks, rel_height=0.5)
+            width_value = widths[0][0]
+            if width_value == 0:
+                self._logger.error("   1-2. Detected peak width is zero.")
+                raise ValueError("Detected peak width is zero.")
+
+            start_index = int(peak_index - 2 * width_value)
+            end_index = int(peak_index + 6 * width_value)
+            start_index = max(start_index, 0)
+            end_index = min(end_index, len(data))
+            self._logger.info(
+                "       Estimated interval indices: start_index=%d, end_index=%d.",
+                start_index,
+                end_index,
+            )
+            interval_data = data.iloc[start_index:end_index].copy()
+
+            # Log time interval statistics.
+            dt = np.diff(interval_data["time"].values)
+            if np.any(dt <= 0):
+                self._logger.warning("   1-2. Time values are not strictly increasing")
+                interval_data = (
+                    interval_data.groupby("time")["thrust"].mean().reset_index()
+                )  # 중복된 시간값에 대해 평균 계산
+                dt = np.diff(interval_data["time"].values)
+            self._logger.info(
+                "       Time interval statistics: min=%.6f, max=%.6f, mean=%.6f",
+                dt.min(),
+                dt.max(),
+                dt.mean(),
+            )
+
+            # (Optional) Plot time interval distribution for debugging.
+            plt.figure(figsize=(10, 6))
+            plt.plot(interval_data["time"].iloc[1:], dt, "b.", markersize=2)
+            plt.xlabel("Time (s)")
+            plt.ylabel("dt (s)")
+            plt.title("Time Interval Distribution")
+            plt.grid(True)
+            plt.show()
+
+            self._logger.info("   1-2. Interval estimation complete.")
+            return interval_data
+
+        except Exception as e:
+            self._logger.error(
+                "   1-2. Error during interval estimation: %s", e, exc_info=True
+            )
+            raise
+
+    # Step 1-3: Change to an evenly-spaced data with interpolation
+    def _interpolate(self, data: pd.DataFrame) -> pd.DataFrame:
+        """Interpolate thrust data using PCHIP to a uniform timestep.
+
+        Args:
+            data (pd.DataFrame): DataFrame with 'time' and 'thrust' columns.
+
+        Returns:
+            pd.DataFrame: Interpolated DataFrame with evenly spaced time points.
+
+        Raises:
+            ValueError: If interpolation fails due to invalid input data.
+        """
+        self._logger.info("   1-3. Starting interpolation of thrust data.")
+
+        # PCHIP (Piecewise Cubic Hermite Interpolating Polynomial) interpolation
+        # https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.PchipInterpolator.html
+        #
+        # - 단조성 보장: 시간에 따라 증가하거나 감소하는 경향성 유지
+        # - 급격한 변화와 이상치에 덜 민감
+        # - Cubic Spline과 달리 급격한 변화가 있는 경우에도 과도한 진동(overshooting) 발생하지 않음
+        # - 단, 계산 비용은 약간 더 커짐
+
+        try:
+            time_interval = 1 / frequency
+            time_interpolated = np.arange(0, data["time"].max(), time_interval)
+            pchip_interp = PchipInterpolator(data["time"], data["thrust"])
+            thrust_interpolated = pchip_interp(time_interpolated)
+            data_interpolated = pd.DataFrame(
+                {"time": time_interpolated, "thrust": thrust_interpolated}
+            )
+            self._logger.info(
+                "   1-3. Interpolation complete. Generated %d data points.",
+                len(data_interpolated),
+            )
+            return data_interpolated
+        except Exception as e:
+            self._logger.error(
+                "   1-3. Error during interpolation: %s", e, exc_info=True
+            )
+            raise
+
+    # Step 1-4: Low Pass Filter (LPF)
+    def _low_pass_filter(self, data: pd.DataFrame) -> pd.DataFrame:
+        """Apply a low-pass Butterworth filter to the interpolated thrust data.
+
+        Args:
+            data (pd.DataFrame): DataFrame with 'time' and 'thrust' columns.
+
+        Returns:
+            pd.DataFrame: Low-pass filtered data.
+        """
+        self._logger.info("   1-4. Applying low-pass filter to thrust data.")
+        try:
+            normal_cutoff = 2 * cutoff_frequency / frequency
+            b, a = butter(lowpass_order, normal_cutoff, btype="low", analog=False)
+            thrust_filtered = lfilter(b, a, data["thrust"])
+            data_lpf = pd.DataFrame({"time": data["time"], "thrust": thrust_filtered})
+            self._logger.info("   1-4. Low-pass filtering complete.")
+            return data_lpf
+        except Exception as e:
+            self._logger.error(
+                "   1-4. Error during low-pass filtering: %s", e, exc_info=True
+            )
+            raise
+
+    # Step 1
+    def _data_preset(self) -> None:
+        """Preprocess raw data: interval estimate → interpolate → LPF → Gaussian."""
+        self._logger.info("1. Starting data preset process.")
+        try:
+            self._data_raw = self._convert_voltage_to_thrust(self._data_raw)
+            data_interval = self._estimate_interval(self._data_raw)
+            data_interval = data_interval.reset_index(drop=True)
+            data_interval["time"] = (
+                data_interval["time"] - data_interval["time"].iloc[0]
+            )
+            data_interpolated = self._interpolate(data_interval)
+            data_filtered = self._low_pass_filter(data_interpolated)
+            self._data = self._gaussian_filter(data_filtered, gaussian_weak_sigma)
+            self._logger.info("1. Data preset process complete.")
+        except Exception as e:
+            self._logger.error("Error during data preset: %s", e, exc_info=True)
+            raise
+
+    # Subfunction of step 2
+    def _check_interval_criteria(
+        self, diff: np.ndarray, max_index: int, min_index: int
+    ) -> tuple[int, int]:
+        """Adjust start/end indices based on predefined threshold criteria.
+
+        Args:
+            diff (np.ndarray): Array of differences between consecutive thrust values.
+            max_index (int): Index corresponding to the maximum increase.
+            min_index (int): Index corresponding to the maximum decrease.
+
+        Returns:
+            Tuple[int, int]: (start_index, end_index) after applying the criteria.
+        """
+        self._logger.info("   2-1. Checking interval criteria for indices.")
+        start_index, end_index = max_index, min_index
+        try:
+            # Adjust start_index: move backward until the ratio is below the start_criteria.
+            while start_index > 0 and diff[start_index] / np.max(diff) > start_criteria:
+                start_index -= 1
+            # Adjust end_index: move forward until the ratio is below the end_criteria.
+            while (
+                end_index < len(diff) - 1
+                and diff[end_index] / np.min(diff) > end_criteria
+            ):
+                end_index += 1
+        except Exception as e:
+            self._logger.error(
+                "   2-1. Error while checking interval criteria: %s", e, exc_info=True
+            )
+            raise
+
+        self._logger.info(
+            "   2-1. Adjusted indices: start_index=%d, end_index=%d.",
+            start_index,
+            end_index,
+        )
+        return (start_index, end_index)
+
+    # Step 2: Select meaningful interval
+    def _find_interval(self) -> None:
+        """Identify and extract a meaningful time interval from processed thrust data."""
+        self._logger.info("2. Finding meaningful data interval.")
+        try:
+            thrust_values = self._data["thrust"].values
+            if len(thrust_values) < 2:
+                self._logger.error("Insufficient data points for finding interval.")
+                raise ValueError("Insufficient data points for finding interval.")
+
+            # Compute the difference between consecutive thrust values.
+            diff = np.diff(thrust_values)
+            diff_filtered = gaussian_filter1d(diff, gaussian_strong_sigma)
+            max_index = int(np.argmax(diff_filtered))
+            min_index = int(np.argmin(diff_filtered))
+            self._logger.info(
+                "   Initial max_index=%d, min_index=%d based on diff.",
+                max_index,
+                min_index,
+            )
+            start_index, end_index = self._check_interval_criteria(
+                diff_filtered, max_index, min_index
+            )
+
+            self._data_cut = self._data.iloc[start_index:end_index].copy()
+            self._data_cut = self._data_cut.reset_index(drop=True)
+            self._data_cut["time"] = (
+                self._data_cut["time"] - self._data_cut["time"].iloc[0]
+            )
+            self._logger.info(
+                "2. Found interval from index %d to %d.", start_index, end_index
+            )
+        except Exception as e:
+            self._logger.error("2. Error in finding interval: %s", e, exc_info=True)
+            raise
+
+    # Step 3: linear shifting from the start point to the end point
+    def _shift(self) -> None:
+        """Apply a linear shift to the cut thrust data to remove baseline drift and compute the impulse.
+
+        The impulse is calculated using Simpson's integration.
+        """
+        self._logger.info("3. Starting thrust data shifting.")
+        try:
+            if self._data_cut.empty:
+                self._logger.error(
+                    "_data_cut is empty. Cannot perform shift operation."
+                )
+                raise ValueError("_data_cut is empty.")
+
+            thrust_initial = self._data_cut["thrust"].iloc[0]
+            thrust_final = self._data_cut["thrust"].iloc[-1]
+            time_total = self._data_cut["time"].iloc[-1]
+            if time_total == 0:
+                self._logger.error("Total time is zero. Cannot shift data.")
+                raise ValueError("Total time is zero.")
+
+            # Compute the linear baseline.
+            slope = (thrust_final - thrust_initial) / time_total
+            thrust_shifted = (
+                self._data_cut["thrust"]
+                - thrust_initial
+                - slope * self._data_cut["time"]
+            )
+            # (2025.03.06.) Remove negative values
+            thrust_shifted = thrust_shifted - min(thrust_shifted.min(), 0)
+
+            self._data_shifted = pd.DataFrame(
+                {"time": self._data_cut["time"].copy(), "thrust": thrust_shifted}
+            )
+            self._impulse = simpson(
+                self._data_shifted["thrust"], x=self._data_shifted["time"]
+            )
+            self._max_thrust_index = self._data_shifted["thrust"].idxmax()
+            self._logger.info(
+                "3. Data shifting complete. Computed impulse: %.3f Ns.", self._impulse
+            )
+            self._logger.info(
+                "3. Max thrust: %f N at time: %.2f s.",
+                self._data_shifted["thrust"].iloc[self._max_thrust_index],
+                self._data_shifted["time"].iloc[self._max_thrust_index],
+            )
+            self._logger.info("3. Max thrust index: %d.", self._max_thrust_index)
+            self._logger.info(
+                "3. Min thrust: %.2f N", self._data_shifted["thrust"].min()
+            )
+        except Exception as e:
+            self._logger.error("3. Error during shifting: %s", e, exc_info=True)
+            raise
+
+    # Subfunction of step 4
+    def _find_time(self) -> tuple[int, int, int]:
+        """Determine key time indices for the thrust curve.
+
+        - start_index: First index where thrust exceeds 10% of the maximum.
+        - burn_time_index: Index (moving backward from the max) where thrust exceeds 75% of the maximum.
+        - action_time_index: Index (moving backward from the max) where thrust is above 10% of the maximum.
+
+        Returns:
+            Tuple[int, int, int]: (start_index, burn_time_index, action_time_index)
+
+        Raises:
+            ValueError: If the indices cannot be determined.
+        """
+        self._logger.info("   4-1. Finding key time indices from shifted data.")
+        try:
+            thrust_series = self._data_shifted["thrust"]
+            max_thrust = thrust_series.max()
+            if max_thrust <= 0:
+                self._logger.error(
+                    "Maximum thrust is non-positive. Invalid data for time index determination."
+                )
+                raise ValueError("Maximum thrust is non-positive.")
+
+            start_index = 0
+            burn_time_index = thrust_series.idxmax()
+            action_time_index = thrust_series.idxmax()
+
+            # Find the start index: first index where thrust exceeds 10% of max.
+            while (
+                start_index < len(thrust_series)
+                and thrust_series.iloc[start_index] < 0.05 * max_thrust
+            ):
+                start_index += 1
+            if start_index >= len(thrust_series):
+                self._logger.error(
+                    "Unable to find start index where thrust exceeds 5%% of max."
+                )
+                raise ValueError("Start index not found.")
+
+            # Adjust burn_time_index: move backwards until thrust is at least 75% of max.
+            while (
+                burn_time_index > 0
+                and thrust_series.iloc[burn_time_index] < 0.75 * max_thrust
+            ):
+                burn_time_index -= 1
+            if burn_time_index < 0:
+                self._logger.error("Unable to determine burn time index.")
+                raise ValueError("Burn time index not found.")
+
+            # Adjust action_time_index: move backwards until thrust is above 10% of max.
+            while (
+                action_time_index > 0
+                and thrust_series.iloc[action_time_index] < 0.1 * max_thrust
+            ):
+                action_time_index -= 1
+            if action_time_index < 0:
+                self._logger.error("Unable to determine action time index.")
+                raise ValueError("Action time index not found.")
+
+            self._logger.info(
+                "   4-1. Key time indices found: start_index=%d, burn_time_index=%d, action_time_index=%d.",
+                start_index,
+                burn_time_index,
+                action_time_index,
+            )
+            return (start_index, burn_time_index, action_time_index)
+        except Exception as e:
+            self._logger.error(
+                "   4-1. Error while finding time indices: %s", e, exc_info=True
+            )
+            raise
+
+    # Step 4
+    def _thrust_plot(self) -> None:
+        """Plot the shifted thrust data with annotations and save the plot to a file."""
+        self._logger.info("4. Plotting thrust data.")
+        try:
+            start_index, burn_time_index, action_time_index = self._find_time()
+            total_time = self._data_shifted["time"].iloc[-1]
+
+            max_thrust = max(self._data_shifted["thrust"])
+            max_thrust_time = self._data_shifted["time"][self._max_thrust_index]
+            x = [max_thrust_time, total_time]
+            y = [max_thrust, 0]
+
+            fig, ax = plt.subplots(figsize=(16, 9))
+            ax.plot(
+                self._data_shifted["time"],
+                self._data_shifted["thrust"],
+                color="black",
+                linewidth=2.5,
+                zorder=0,
+            )
+            ax.scatter(x, y, marker="o", color="red", s=120, zorder=1)
+
+            ax.set_xlim([0, 1.11 * total_time])
+            ax.set_ylim([-0.05 * max_thrust, 1.12 * max_thrust])
+
+            ax.annotate(
+                "Max Thrust   " + str(round(max_thrust, 2)) + " N",
+                xy=(max_thrust_time / total_time * 0.65, 0.94),
+                xycoords="axes fraction",
+                size=20,
+                font="Arial",
+            )
+
+            ax.annotate(
+                "Total Time\n" + str(round(total_time, 2)) + " s",
+                xy=(0.89, 0.12),
+                xycoords="axes fraction",
+                size=20,
+                font="Arial",
+            )
+
+            ax.annotate(
+                "Impulse            " + str(round(self._impulse, 2)) + " Ns\n"
+                "Input Voltage   " + str(round(self._input_voltage, 2)) + " V\n"
+                "Resistance       " + str(round(self._resistance, 2)) + r" $\Omega$",
+                xy=(0.72, 0.85),
+                xycoords="axes fraction",
+                size=20,
+                font="Arial",
+            )
+
+            ax.set_xlabel("Time [s]", size=20, font="Arial")
+            ax.xaxis.set_label_coords(0.5, -0.07)
+            ax.set_ylabel("Thrust [N]", size=20, font="Arial")
+            ax.yaxis.set_label_coords(-0.07, 0.5)
+            fig.suptitle(
+                self._file_name + " Thrust Graph",
+                y=0.95,
+                fontsize=25,
+                fontweight="bold",
+                font="Arial",
+            )
+            ax.grid(True)
+            ax.tick_params(axis="both", which="major", labelsize=15)
+            output_dir = os.path.join("..", "thrust_graph")
+            os.makedirs(output_dir, exist_ok=True)
+            output_path = os.path.join(output_dir, f"{self._file_name}_thrust.png")
+            plt.savefig(output_path, bbox_inches=None, pad_inches=0, dpi=500)
+            plt.show()
+            self._logger.info("4. Thrust plot saved to %s", output_path)
+        except Exception as e:
+            self._logger.error(
+                "4. Error during plotting thrust data: %s", e, exc_info=True
+            )
+            raise
+
+    # Step 5
+    def _data_save(self) -> None:
+        """Save processed thrust data to a CSV file."""
+        self._logger.info("5. Saving processed thrust data.")
+        try:
+            output_dir = os.path.join(
+                os.path.dirname(self._BASE_DIR), "thrust_post_process"
+            )
+            os.makedirs(output_dir, exist_ok=True)
+            output_file = os.path.join(output_dir, f"{self._file_name}_thrust.csv")
+            # self._data_shifted.to_csv('./../thrust_post_process/'+self._file_name+ '_thrust.txt', sep = ' ', index=False)
+            self._data_shifted.copy().to_csv(output_file, index=False)
+            self._logger.info("5. Data saved successfully to %s", output_file)
+        except Exception as e:
+            self._logger.error("5. Error saving data: %s", e, exc_info=True)
+            raise
+
+    def run(self) -> pd.DataFrame:
+        """Run the full thrust data processing pipeline."""
+        self._logger.info("Starting thrust data processing pipeline.")
+        self._data_preset()
+        self._find_interval()
+        self._shift()
+        self._thrust_plot()
+        self._data_save()
+        self._logger.info("Thrust data processing pipeline complete.")
+        return self._data_shifted
+
+
+if __name__ == "__main__":
+    # Read config.xlsx
+    base_dir = os.path.dirname(__file__)
+    config_path = os.path.join(os.path.dirname(base_dir), "config.xlsx")
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(f"Configuration file not found: {config_path}")
+
+    config = pd.read_excel(config_path, sheet_name=0, header=0, index_col=0)
+    idx = len(config) - 1
+    expt_file_name = config["expt_file_name"][idx]
+    expt_input_voltage = config["expt_input_voltage [V]"][idx]
+    expt_resistance = config["expt_resistance [Ohm]"][idx]
+
+    print(f"Loaded configuration for experiment: {expt_file_name}")
+
+    # 파일 경로 설정
+    raw_data_path = os.path.join(os.path.dirname(base_dir), "_thrust_raw/")
+    csv_path = os.path.join(raw_data_path, f"{expt_file_name}_thrust_raw.csv")
+    txt_path = os.path.join(raw_data_path, f"{expt_file_name}_thrust_raw.txt")
+
+    # csv 파일이 존재하면 csv 파일을, 아니면 txt 파일을 읽음
+    if os.path.exists(csv_path):
+        data_file = csv_path
+        print(f"Using CSV thrust data file: {csv_path}")
+    elif os.path.exists(txt_path):
+        data_file = txt_path
+        print(f"Using TXT thrust data file: {txt_path}")
+    else:
+        error_msg = f"No thrust data file found at {csv_path} or {txt_path}"
+        print(error_msg)
+        raise FileNotFoundError(error_msg)
+
+    thrust_data = pd.read_csv(
+        data_file, sep="[,\t]", header=None, engine="python"
+    )  # 기존 데이터 형식과도 호환되도록 구분자로 쉼표(,) 및 탭(\t) 사용
+    print("Successfully loaded input data file.")
+
+    process = ThrustPostProcess(
+        thrust_data, expt_file_name, expt_input_voltage, expt_resistance
+    )
+    _ = process.run()


### PR DESCRIPTION
## Summary
- Add `static_fire_toolkit/config_loader.py` to load runtime parameters from execution-root `global_config.py` (fallback to safe defaults)
- Remove wildcard imports in post-processing modules; bind explicit variables via loader
- Fix docstrings/import order flagged by ruff (D101/D205/D415, E402) and keep pre-commit green

## Checklist
- [x] CI passes (lint + tests)
- [ ] Docs/README updated (if behavior/user-facing changes)
- [ ] Version bump planned if needed (release via tag `vX.Y.Z`)

## Notes
- Config
  - New loader: `load_global_config()` reads execution-root `global_config.py`; accepts UPPERCASE/lowercase names; returns `Config` dataclass with defaults.
  - Updated modules:
    - `src/static_fire_toolkit/post_process/thrust_post_processing.py`
    - `src/static_fire_toolkit/post_process/pressure_post_processing.py`
  - Explicit variables now sourced from loader: `rated_output`, `rated_load`, `g`, `frequency`, `cutoff_frequency`, `lowpass_order`, `gaussian_weak_sigma`, `gaussian_strong_sigma`, `start_criteria`, `end_criteria`.
- Linting
  - Docstrings normalized (D101/D200/D205/D415), import order fixed (E402), unused variables removed.
  - Pre-commit (ruff-check/format) passes locally.
- Backward Compatibility
  - If `global_config.py` is absent, defaults are used; users should place project-specific `global_config.py` at run root.
- Follow-ups (separate PRs)
  - Unify I/O paths to `logs/` and `results/*` under execution root.
  - Wire real CLI subcommands and replace temporary `sft` entry point.
