### PR TITLE
feat: unify I/O paths to logs/ and results/*

### DIFF
--- a/src/static_fire_toolkit/burnrate_calc/analyze_burnrate.py
+++ b/src/static_fire_toolkit/burnrate_calc/analyze_burnrate.py
@@ -39,13 +39,17 @@ class BurnRateAnalyzer:
         """
         # Define file paths
         self._BASE_DIR = os.path.abspath(os.path.dirname(__file__))
-        self.output_data_dir = os.path.join(self._BASE_DIR, "burnrate")
-        self.output_graph_dir = os.path.join(self._BASE_DIR, "burnrate_graph")
+        # Use execution root for all I/O (logs/results)
+        self._EXEC_ROOT = os.path.abspath(os.getcwd())
+        self.output_data_dir = os.path.join(self._EXEC_ROOT, "results", "burnrate")
+        self.output_graph_dir = os.path.join(
+            self._EXEC_ROOT, "results", "burnrate_graph"
+        )
 
         # Set up logging
         self._logger = logging.getLogger(__name__)
         self._BASE_DIR = os.path.abspath(os.path.dirname(__file__))
-        log_dir = os.path.join(self._BASE_DIR, "logs")
+        log_dir = os.path.join(self._EXEC_ROOT, "logs")
         os.makedirs(log_dir, exist_ok=True)
         log_filename = os.path.join(log_dir, f"{file_name}-burnrate_analysis.log")
 
@@ -623,9 +627,9 @@ class BurnRateAnalyzer:
 
 
 if __name__ == "__main__":
-    # Read config.xlsx
-    base_dir = os.path.dirname(__file__)
-    config_path = os.path.join(os.path.dirname(base_dir), "config.xlsx")
+    # Read config.xlsx from execution root
+    EXEC_ROOT = os.path.abspath(os.getcwd())
+    config_path = os.path.join(EXEC_ROOT, "config.xlsx")
     if not os.path.exists(config_path):
         print(f"Configuration file not found: {config_path}")
         raise FileNotFoundError(f"Configuration file not found: {config_path}")
@@ -663,7 +667,7 @@ if __name__ == "__main__":
     print(f"Loaded configuration for experiment: {expt_file_name}")
 
     # Determine the file to process using the configuration file
-    pressure_data_dir = os.path.join(os.path.dirname(base_dir), "pressure_post_process")
+    pressure_data_dir = os.path.join(EXEC_ROOT, "results", "pressure")
     filename_csv = expt_file_name + "_pressure.csv"
     filename_txt = expt_file_name + "_pressure.txt"
 

--- a/src/static_fire_toolkit/post_process/pressure_post_processing.py
+++ b/src/static_fire_toolkit/post_process/pressure_post_processing.py
@@ -69,7 +69,9 @@ class PressurePostProcess:
         # Set up logging
         self._logger = logging.getLogger(__name__)
         self._BASE_DIR = os.path.abspath(os.path.dirname(__file__))
-        log_dir = os.path.join(self._BASE_DIR, "logs")
+        # Use execution root for all I/O (logs/results)
+        self._EXEC_ROOT = os.path.abspath(os.getcwd())
+        log_dir = os.path.join(self._EXEC_ROOT, "logs")
         os.makedirs(log_dir, exist_ok=True)
         log_filename = os.path.join(log_dir, f"{file_name}-pressure_processing.log")
 
@@ -493,7 +495,8 @@ class PressurePostProcess:
 
             # Save and display
             save_path = os.path.join(
-                os.path.dirname(self._BASE_DIR),
+                self._EXEC_ROOT,
+                "results",
                 "pressure_graph",
                 f"{self._file_name}_pressure.png",
             )
@@ -514,9 +517,7 @@ class PressurePostProcess:
         """Save processed pressure data to CSV file."""
         self._logger.info("5. Saving processed pressure data")
         try:
-            save_dir = os.path.join(
-                os.path.dirname(self._BASE_DIR), "pressure_post_process"
-            )
+            save_dir = os.path.join(self._EXEC_ROOT, "results", "pressure")
             os.makedirs(save_dir, exist_ok=True)
             save_path = os.path.join(save_dir, f"{self._file_name}_pressure.csv")
 
@@ -540,9 +541,9 @@ class PressurePostProcess:
 
 
 if __name__ == "__main__":
-    # Read config.xlsx
-    base_dir = os.path.dirname(__file__)
-    config_path = os.path.join(os.path.dirname(base_dir), "config.xlsx")
+    # Read config.xlsx from execution root
+    EXEC_ROOT = os.path.abspath(os.getcwd())
+    config_path = os.path.join(EXEC_ROOT, "config.xlsx")
     if not os.path.exists(config_path):
         print(f"Configuration file not found: {config_path}")
         raise FileNotFoundError(f"Configuration file not found: {config_path}")
@@ -553,8 +554,8 @@ if __name__ == "__main__":
     print(f"Loaded configuration for experiment: {expt_file_name}")
 
     # Set up file paths
-    thrust_dir = os.path.join(os.path.dirname(base_dir), "thrust_post_process")
-    pressure_raw_dir = os.path.join(os.path.dirname(base_dir), "_pressure_raw")
+    thrust_dir = os.path.join(EXEC_ROOT, "results", "thrust")
+    pressure_raw_dir = os.path.join(EXEC_ROOT, "data", "_pressure_raw")
 
     # Define file paths
     thrust_csv_path = os.path.join(thrust_dir, f"{expt_file_name}_thrust.csv")

--- a/src/static_fire_toolkit/post_process/thrust_post_processing.py
+++ b/src/static_fire_toolkit/post_process/thrust_post_processing.py
@@ -85,7 +85,9 @@ class ThrustPostProcess:
         # Set up logging
         self._logger = logging.getLogger(__name__)
         self._BASE_DIR = os.path.abspath(os.path.dirname(__file__))
-        log_dir = os.path.join(self._BASE_DIR, "logs")
+        # Use execution root for all I/O (logs/results)
+        self._EXEC_ROOT = os.path.abspath(os.getcwd())
+        log_dir = os.path.join(self._EXEC_ROOT, "logs")
         os.makedirs(log_dir, exist_ok=True)
         log_filename = os.path.join(log_dir, f"{file_name}-thrust_processing.log")
 
@@ -628,7 +630,7 @@ class ThrustPostProcess:
             )
             ax.grid(True)
             ax.tick_params(axis="both", which="major", labelsize=15)
-            output_dir = os.path.join("..", "thrust_graph")
+            output_dir = os.path.join(self._EXEC_ROOT, "results", "thrust_graph")
             os.makedirs(output_dir, exist_ok=True)
             output_path = os.path.join(output_dir, f"{self._file_name}_thrust.png")
             plt.savefig(output_path, bbox_inches=None, pad_inches=0, dpi=500)
@@ -645,9 +647,7 @@ class ThrustPostProcess:
         """Save processed thrust data to a CSV file."""
         self._logger.info("5. Saving processed thrust data.")
         try:
-            output_dir = os.path.join(
-                os.path.dirname(self._BASE_DIR), "thrust_post_process"
-            )
+            output_dir = os.path.join(self._EXEC_ROOT, "results", "thrust")
             os.makedirs(output_dir, exist_ok=True)
             output_file = os.path.join(output_dir, f"{self._file_name}_thrust.csv")
             # self._data_shifted.to_csv('./../thrust_post_process/'+self._file_name+ '_thrust.txt', sep = ' ', index=False)
@@ -670,9 +670,9 @@ class ThrustPostProcess:
 
 
 if __name__ == "__main__":
-    # Read config.xlsx
-    base_dir = os.path.dirname(__file__)
-    config_path = os.path.join(os.path.dirname(base_dir), "config.xlsx")
+    # Read config.xlsx from execution root
+    EXEC_ROOT = os.path.abspath(os.getcwd())
+    config_path = os.path.join(EXEC_ROOT, "config.xlsx")
     if not os.path.exists(config_path):
         raise FileNotFoundError(f"Configuration file not found: {config_path}")
 
@@ -685,7 +685,7 @@ if __name__ == "__main__":
     print(f"Loaded configuration for experiment: {expt_file_name}")
 
     # 파일 경로 설정
-    raw_data_path = os.path.join(os.path.dirname(base_dir), "_thrust_raw/")
+    raw_data_path = os.path.join(EXEC_ROOT, "data", "_thrust_raw")
     csv_path = os.path.join(raw_data_path, f"{expt_file_name}_thrust_raw.csv")
     txt_path = os.path.join(raw_data_path, f"{expt_file_name}_thrust_raw.txt")
 


### PR DESCRIPTION
## Summary
- I/O 경로 일원화: 실행 루트 기준으로 저장/로그 경로 통일
  - Thrust: `results/thrust`, `results/thrust_graph`
  - Pressure: `results/pressure`, `results/pressure_graph`
  - Burnrate: `results/burnrate`, `results/burnrate_graph`
- 각 모듈의 `__main__` 경로 정리
  - 입력: `data/_thrust_raw`, `data/_pressure_raw`
  - 출력: `results/*`
- 로깅 경로 일원화: `logs/` 사용

## Rationale
- 실행 위치에 따른 경로 오작동 방지
- 문서화된 디렉터리 규약과 일치
- 후속 오케스트레이션/CLI 작업을 위한 기반 정리

## Backward Compatibility
- **Breaking Changes**: 기존 예제 경로와 다른 저장소 구조를 사용하므로, 예전 하드코딩 경로 의존 스크립트는 업데이트 필요
- 데이터 로더는 동일 포맷 유지(csv/`;` 구분자)

## Checklist
- [x] CI passes (lint + tests)
- [ ] Docs/README updated (if behavior/user-facing changes)
- [ ] Version bump planned if needed (release via tag `vX.Y.Z`)

## Notes
- 다음 단계: `feat/cli` 브랜치에서 CLI 서브커맨드 구현 및 엔트리포인트 교체
- `process_all.py`는 별도 리팩터링 항목으로 유지 (이번 PR 범위에는 포함하지 않음)
