### PR TITLE
chore(cli): add module entry point

### DIFF
--- a/src/static_fire_toolkit/__main__.py
+++ b/src/static_fire_toolkit/__main__.py
@@ -1,0 +1,9 @@
+"""Package entry point for `python -m static_fire_toolkit`.
+
+Delegates execution to `static_fire_toolkit.cli.main()`.
+"""
+
+from static_fire_toolkit.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add module entry point to support `python3 -m static_fire_toolkit`

## Checklist
- [x] CI passes (lint + tests)
- [ ] Docs/README updated (if behavior/user-facing changes)
- [ ] Version bump planned if needed (release via tag `vX.Y.Z`)

## Notes
- 기능 변경 없음
