### PR TITLE
chore(ci): add openpyxl to min constraints for read_excel

### DIFF
--- a/constraints-min.txt
+++ b/constraints-min.txt
@@ -4,3 +4,4 @@ pandas==2.0.*
 scipy==1.13.*
 matplotlib==3.10.*
 contourpy==1.3.*
+openpyxl==3.1.*


### PR DESCRIPTION
## Summary
- CI 최소 제약(min constraints)에 openpyxl==3.1.* 추가
  - pandas read_excel 엔진 보장을 위해 min 매트릭스에서도 openpyxl을 확실히 설치
  - 런타임 의존성(pyproject.toml의 openpyxl>=3.1)과 일관성 유지

## Checklist
- [x] CI passes (lint + tests)
- [ ] Docs/README updated (if behavior/user-facing changes)
- [ ] Version bump planned if needed (release via tag `vX.Y.Z`)

## Notes
- 변경 파일: constraints-min.txt (openpyxl==3.1.* 추가)
- GitHub Actions는 이미 -c constraints-min.txt를 사용하므로 워크플로우 수정은 불필요
- 기능/동작 변경 없음, CI 안정성 개선 목적
