### PR TITLE
Chore/remove legacy core

### DIFF
--- a/src/static_fire_toolkit/core.py
+++ b/src/static_fire_toolkit/core.py
@@ -1,3 +1,0 @@
-# ruff: noqa: D103
-def hello() -> str:
-    return "Hello from static-fire-toolkit!"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,0 @@
-# ruff: noqa: D103
-from static_fire_toolkit.core import hello
-
-
-def test_hello():
-    assert "static-fire-toolkit" in hello()


### PR DESCRIPTION
## Summary
- 레거시/임시 엔트리포인트 및 플레이스홀더 테스트 제거
  - src/static_fire_toolkit/core.py 삭제
  - tests/test_core.py 삭제

## Checklist
- [x] CI passes (lint + tests)
- [ ] Docs/README updated (if behavior/user-facing changes)
- [ ] Version bump planned if needed (release via tag `vX.Y.Z`)

## Notes
- 현재 실제 CLI 엔트리포인트는 static_fire_toolkit.cli:main이며, python -m static_fire_toolkit도 지원
- 기능 변경 없음(과거 임시로 추가해 두었던 불필요한 엔트리포인트 제거)
