### PR TITLE
fix(typing): use numpy.ndarray in type hints and enable future annotations

### DIFF
--- a/src/static_fire_toolkit/burnrate_calc/analyze_burnrate.py
+++ b/src/static_fire_toolkit/burnrate_calc/analyze_burnrate.py
@@ -10,6 +10,8 @@ HANARO, Seoul National University Rocket Team
 - Added data validation and warning messages
 """
 
+from __future__ import annotations
+
 import os
 import logging
 import pandas as pd
@@ -171,23 +173,25 @@ class BurnRateAnalyzer:
             raise
 
     @staticmethod
-    def saint_roberts_law(P: float | np.array, a: float, n: float) -> float | np.array:
+    def saint_roberts_law(
+        P: float | np.ndarray, a: float, n: float
+    ) -> float | np.ndarray:
         """Saint Robert's Law (Vieille's Law): r = a * P^n.
 
         Parameters:
-            P (float or np.array): Pressure in MPa.
+            P (float or np.ndarray): Pressure in MPa.
             a (float): Coefficient (experimentally determined).
             n (float): Exponent (experimentally determined).
 
         Returns:
-            float or np.array: Burn rate in mm/s.
+            float or np.ndarray: Burn rate in mm/s.
         """
         return a * np.power(P, n)
 
     # Step 2: Calculate burnrate
     def calc_burnrate(
         self, pressure_data: pd.DataFrame
-    ) -> tuple[np.array, np.array, float, float]:
+    ) -> tuple[np.ndarray, np.ndarray, float | None, float | None]:
         """Calculate burnrate using RK4 and fit an ideal burnrate curve.
 
         The ideal curve is computed using Saint Robert's Law.
@@ -197,8 +201,8 @@ class BurnRateAnalyzer:
 
         Returns:
             tuple: (burnrate, burnrate_ideal, a_fit, n_fit)
-                burnrate (np.array): Calculated burnrate at each time step (mm/s).
-                burnrate_ideal (np.array): Ideal burnrate from curve fitting (mm/s).
+                burnrate (np.ndarray): Calculated burnrate at each time step (mm/s).
+                burnrate_ideal (np.ndarray): Ideal burnrate from curve fitting (mm/s).
                 a_fit (float): Fitted coefficient a.
                 n_fit (float): Fitted exponent n.
         """


### PR DESCRIPTION
## Summary
- 타입 힌트 수정으로 CLI 상에서 `sft` 실행 시 발생하던 `TypeError` 해결
  - `from __future__ import annotations` 도입으로 Python 3.11 미만 버전에서도 어노테이션 지연 평가
  - `np.array` → `np.ndarray`로 정정, 반환/튜플 타입 명시 정리

## Checklist
- [x] CI passes (lint + tests)
- [ ] Docs/README updated (if behavior/user-facing changes)
- [ ] Version bump planned if needed (release via tag `vX.Y.Z`)

## Notes
- 후속 작업(별도 PR): `cli.py`의 무거운 모듈을 서브커맨드 내부로 지연 import하여 경량 명령(`--version`, `info`) 실행 속도 및 안정성 개선 예정
