### PR TITLE
fix(cli): respect --root for outputs (logs/results)

### DIFF
--- a/src/static_fire_toolkit/burnrate_calc/analyze_burnrate.py
+++ b/src/static_fire_toolkit/burnrate_calc/analyze_burnrate.py
@@ -30,7 +30,11 @@ class BurnRateAnalyzer:
     """A class for analyzing the burnrate of a solid rocket motor fuel based on pressure data."""
 
     def __init__(
-        self, pressure_data: pd.DataFrame, grain: dict, file_name: str
+        self,
+        pressure_data: pd.DataFrame,
+        grain: dict,
+        file_name: str,
+        execution_root: str | None = None,
     ) -> None:
         """Initialize the analyzer with pressure data, grain parameters, and file metadata.
 
@@ -42,7 +46,7 @@ class BurnRateAnalyzer:
         # Define file paths
         self._BASE_DIR = os.path.abspath(os.path.dirname(__file__))
         # Use execution root for all I/O (logs/results)
-        self._EXEC_ROOT = os.path.abspath(os.getcwd())
+        self._EXEC_ROOT = os.path.abspath(execution_root or os.getcwd())
         self.output_data_dir = os.path.join(self._EXEC_ROOT, "results", "burnrate")
         self.output_graph_dir = os.path.join(
             self._EXEC_ROOT, "results", "burnrate_graph"

--- a/src/static_fire_toolkit/cli.py
+++ b/src/static_fire_toolkit/cli.py
@@ -127,6 +127,7 @@ def cmd_thrust(args: argparse.Namespace) -> None:
         file_name=cfg["expt_file_name"],
         input_voltage=cfg["expt_input_voltage"],
         resistance=cfg["expt_resistance"],
+        execution_root=str(exec_root),
     )
     _ = proc.run()
 
@@ -157,6 +158,7 @@ def cmd_pressure(args: argparse.Namespace) -> None:
         pressure_data_raw=pressure_raw,
         thrust_data=thrust_data,
         file_name=cfg["expt_file_name"],
+        execution_root=str(exec_root),
     )
     _ = proc.run()
 
@@ -184,6 +186,7 @@ def cmd_burnrate(args: argparse.Namespace) -> None:
         pressure_data=pressure_data,
         grain=cfg["grain"],
         file_name=cfg["expt_file_name"],
+        execution_root=str(exec_root),
     )
     analyzer.run()
 
@@ -203,6 +206,7 @@ def cmd_process(args: argparse.Namespace) -> None:
         file_name=cfg["expt_file_name"],
         input_voltage=cfg["expt_input_voltage"],
         resistance=cfg["expt_resistance"],
+        execution_root=str(exec_root),
     )
     thrust_df = thrust_proc.run()
 
@@ -216,6 +220,7 @@ def cmd_process(args: argparse.Namespace) -> None:
         pressure_data_raw=pressure_raw,
         thrust_data=thrust_df,
         file_name=cfg["expt_file_name"],
+        execution_root=str(exec_root),
     )
     pressure_df = pressure_proc.run()
 
@@ -226,6 +231,7 @@ def cmd_process(args: argparse.Namespace) -> None:
         pressure_data=pressure_df,
         grain=cfg["grain"],
         file_name=cfg["expt_file_name"],
+        execution_root=str(exec_root),
     )
     analyzer.run()
 
@@ -235,7 +241,12 @@ def cmd_info(args: argparse.Namespace) -> None:
     exec_root = Path(args.root or os.getcwd()).resolve()
     config_path = exec_root / "config.xlsx"
 
-    print("Static-Fire Toolkit")
+    print("\nStatic-Fire Toolkit\n")
+    print("(c) 2025 SNU Rocket Team HANARO. Licensed under the MIT License.\n")
+    print("================================================================")
+    print(f"  exec_root      : {exec_root}")
+    print(f"  config.xlsx    : {'present' if config_path.exists() else 'missing'}")
+    print("================================================================")
     print(f"  version        : {__version__}")
     print(f"  python         : {sys.version.split()[0]}")
     print(f"  platform       : {platform.platform()}")
@@ -249,8 +260,7 @@ def cmd_info(args: argparse.Namespace) -> None:
     print(f"  pandas         : {pd.__version__}")
     print(f"  scipy          : {scipy.__version__}")
     print(f"  matplotlib     : {matplotlib.__version__}")
-    print(f"  exec_root      : {exec_root}")
-    print(f"  config.xlsx    : {'present' if config_path.exists() else 'missing'}")
+    print("================================================================")
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/src/static_fire_toolkit/post_process/pressure_post_processing.py
+++ b/src/static_fire_toolkit/post_process/pressure_post_processing.py
@@ -55,7 +55,11 @@ class PressurePostProcess:
     """
 
     def __init__(
-        self, pressure_data_raw: pd.DataFrame, thrust_data: pd.DataFrame, file_name: str
+        self,
+        pressure_data_raw: pd.DataFrame,
+        thrust_data: pd.DataFrame,
+        file_name: str,
+        execution_root: str | None = None,
     ) -> None:
         """Initialize the PressurePostProcess object with raw pressure data and configuration parameters.
 
@@ -63,6 +67,8 @@ class PressurePostProcess:
             pressure_data_raw (pd.DataFrame): Raw data containing time and pressure measurements
             thrust_data (pd.DataFrame): Processed thrust data for synchronization
             file_name (str): File name identifier for logging and output
+            execution_root (str | None): Base directory for logs/ and results/*.
+                If None, defaults to current working directory.
 
         Raises:
             ValueError: If input data is invalid or missing required columns
@@ -71,7 +77,7 @@ class PressurePostProcess:
         self._logger = logging.getLogger(__name__)
         self._BASE_DIR = os.path.abspath(os.path.dirname(__file__))
         # Use execution root for all I/O (logs/results)
-        self._EXEC_ROOT = os.path.abspath(os.getcwd())
+        self._EXEC_ROOT = os.path.abspath(execution_root or os.getcwd())
         log_dir = os.path.join(self._EXEC_ROOT, "logs")
         os.makedirs(log_dir, exist_ok=True)
         log_filename = os.path.join(log_dir, f"{file_name}-pressure_processing.log")

--- a/src/static_fire_toolkit/post_process/thrust_post_processing.py
+++ b/src/static_fire_toolkit/post_process/thrust_post_processing.py
@@ -71,6 +71,7 @@ class ThrustPostProcess:
         file_name: str,
         input_voltage: float,
         resistance: float,
+        execution_root: str | None = None,
     ) -> None:
         """Initialize the ThrustPostProcess object with raw data and configuration parameters.
 
@@ -79,6 +80,8 @@ class ThrustPostProcess:
             file_name (str): File name identifier.
             input_voltage (float): Input voltage used during measurement.
             resistance (float): Resistance value used during measurement.
+            execution_root (str | None): Base directory for logs/ and results/*.
+                If None, defaults to current working directory.
 
         Raises:
             ValueError: If data_raw is not a pandas DataFrame, is empty, or has insufficient columns.
@@ -87,7 +90,7 @@ class ThrustPostProcess:
         self._logger = logging.getLogger(__name__)
         self._BASE_DIR = os.path.abspath(os.path.dirname(__file__))
         # Use execution root for all I/O (logs/results)
-        self._EXEC_ROOT = os.path.abspath(os.getcwd())
+        self._EXEC_ROOT = os.path.abspath(execution_root or os.getcwd())
         log_dir = os.path.join(self._EXEC_ROOT, "logs")
         os.makedirs(log_dir, exist_ok=True)
         log_filename = os.path.join(log_dir, f"{file_name}-thrust_processing.log")


### PR DESCRIPTION
## Summary
- `--root` 인자가 출력 경로에도 일관 적용되도록 수정
  - 처리기 클래스에 `execution_root` 인자 추가: Thrust/Pressure/BurnRate
  - CLI에서 각 서브커맨드 호출 시 `execution_root` 전달
  - 모든 로그/결과물(`logs/`, `results/*`)이 지정한 루트 하위에 생성 

## Checklist
- [x] CI passes (lint + tests)
- [ ] Docs/README updated (if behavior/user-facing changes)
- [ ] Version bump planned if needed (release via tag `vX.Y.Z`)

## Notes
- 입력/출력/로그 경로가 모두 `--root`에 종속되어 reproducible 실행 보장
- 기존 기본 동작(CWD 기준)은 `--root` 미지정 시 그대로 유지
