### PR TITLE
chore(ci): update publish-pypi workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -21,6 +21,22 @@ jobs:
         with:
           python-version: "3.13"
       
+      # Ensure the tag commit belongs to 'main' (avoid releasing from non-main)
+      - name: Verify tag points to main
+        shell: bash
+        run: |
+          # Fetch main to ensure ancestry check is accurate
+          git fetch --no-tags origin main
+          TAG_REF="${GITHUB_REF#refs/tags/}"     # e.g., v1.0.0
+          TAG_SHA="$(git rev-list -n 1 "$TAG_REF")"
+          # Check that TAG_SHA is reachable from origin/main
+          if git merge-base --is-ancestor "$TAG_SHA" origin/main; then
+            echo "OK: $TAG_REF ($TAG_SHA) is contained in origin/main"
+          else
+            echo "ERROR: $TAG_REF ($TAG_SHA) is not on main. Refusing to publish." >&2
+            exit 1
+          fi
+      
       - name: Build
         run: |
           python3 -m pip install --upgrade pip build


### PR DESCRIPTION
## Summary
- Publish (PyPI) 워크플로우 정비
  - 태그가 origin/main에 포함되어 있는지 검증하는 단계 추가(main 이외의 브랜치에서의 태그 릴리즈 방지)

## Checklist
- [x] CI passes (lint + tests)
- [ ] Docs/README updated (if behavior/user-facing changes)
- [ ] Version bump planned if needed (release via tag `vX.Y.Z`)

## Notes
- 영향: 릴리즈 파이프라인의 안전성 향상 (기능 변경 없음)
