### PR TITLE
feat(cli,post-process): support sep/header configuration

### DIFF
--- a/examples/global_config.py
+++ b/examples/global_config.py
@@ -1,11 +1,14 @@
-# ---------- Do not change ----------
+thrust_sep = "[,\t]"  # separator for thrust data, character or Regex
+thrust_header = None  # header for thrust data (row number or None)
+pressure_sep = ";"  # separator for pressure data, character or Regex
+pressure_header = 0  # header for pressure data (row number or None)
 g = 9.80665  # gravitational acceleration, m/s^2
 rated_load = 500  # rated load of load cell, kgf
 rated_output = 3  # rated output of load cell, V
-frequency = 100  # Sampling rate
+frequency = 100  # Sampling rate, Hz
 cutoff_frequency = 30  # LPF, Hz
-gaussian_strong_sigma = 10
-start_criteria = 0.2
-end_criteria = 0.1
-lowpass_order = 5
-gaussian_weak_sigma = 1.5
+gaussian_strong_sigma = 10  # sigma for strong gaussian filter
+start_criteria = 0.2  # Criteria for the starting point of a meaningful interval in thrust data processing
+end_criteria = 0.1  # Criteria for the ending point of a meaningful interval in thrust data processing
+lowpass_order = 5  # order for lowpass filter
+gaussian_weak_sigma = 1.5  # sigma for weak gaussian filter

--- a/src/static_fire_toolkit/cli.py
+++ b/src/static_fire_toolkit/cli.py
@@ -14,6 +14,7 @@ import sys
 import platform
 
 from static_fire_toolkit import __version__
+from static_fire_toolkit.config_loader import load_global_config
 
 if TYPE_CHECKING:  # Only for type checkers; avoids importing pandas at runtime here
     from pandas import DataFrame
@@ -90,7 +91,10 @@ def _read_thrust_raw(execution_root: Path, expt_file_name: str) -> DataFrame:
         )
     import pandas as pd
 
-    return pd.read_csv(data_file, sep="[,\t]", header=None, engine="python")
+    cfg = load_global_config(execution_root)
+    sep = str(getattr(cfg, "thrust_sep", ","))
+    header = getattr(cfg, "thrust_header", 0)
+    return pd.read_csv(data_file, sep=sep, header=header, engine="python")
 
 
 def _read_pressure_raw(execution_root: Path, expt_file_name: str) -> DataFrame:
@@ -106,11 +110,12 @@ def _read_pressure_raw(execution_root: Path, expt_file_name: str) -> DataFrame:
         raise FileNotFoundError(
             f"No pressure data file found for {expt_file_name}: {csv_path} or {txt_path}"
         )
-    # Pressure raw csv typically uses ';'
-    sep = ";" if str(data_file).endswith(".csv") else ","
     import pandas as pd
 
-    return pd.read_csv(data_file, sep=sep, header=0)
+    cfg = load_global_config(execution_root)
+    sep = str(getattr(cfg, "pressure_sep", ","))
+    header = getattr(cfg, "pressure_header", 0)
+    return pd.read_csv(data_file, sep=sep, header=header, engine="python")
 
 
 def cmd_thrust(args: argparse.Namespace) -> None:

--- a/src/static_fire_toolkit/config_loader.py
+++ b/src/static_fire_toolkit/config_loader.py
@@ -24,16 +24,20 @@ from typing import Any
 class Config:
     """Runtime configuration values used by processing modules."""
 
-    rated_output: float = 2.0  # mV/V or sensor unit (example default)
-    rated_load: float = 100.0  # kg or sensor unit (example default)
-    g: float = 9.80665
-    frequency: float = 100.0  # Hz (Δt = 0.01 s)
+    rated_output: float = 3.0  # rated output of load cell, V
+    rated_load: float = 500.0  # rated load of load cell, kgf
+    g: float = 9.80665  # gravitational acceleration, m/s^2
+    frequency: float = 100.0  # Sampling rate, Hz (Δt = 0.01 s)
     cutoff_frequency: float = 10.0  # Hz for LPF
-    lowpass_order: int = 2
-    gaussian_weak_sigma: float = 2.0
-    gaussian_strong_sigma: float = 8.0
-    start_criteria: float = 0.15
-    end_criteria: float = 0.15
+    lowpass_order: int = 5  # order for lowpass filter
+    gaussian_weak_sigma: float = 2.0  # sigma for weak gaussian filter
+    gaussian_strong_sigma: float = 8.0  # sigma for strong gaussian filter
+    start_criteria: float = 0.15  # Criteria for the starting point of a meaningful interval in thrust data processing
+    end_criteria: float = 0.15  # Criteria for the ending point of a meaningful interval in thrust data processing
+    thrust_sep: str = ","  # separator for thrust data, character or Regex
+    thrust_header: int | None = 0  # header for thrust data (row number or None)
+    pressure_sep: str = ","  # separator for pressure data, character or Regex
+    pressure_header: int | None = 0  # header for pressure data (row number or None)
 
 
 def _read_attr(cfg: Any, name: str, default: Any) -> Any:
@@ -70,6 +74,10 @@ def _load_from_python(path: Path, base: Config) -> Config:
                 _read_attr(mod, "start_criteria", base.start_criteria)
             ),
             end_criteria=float(_read_attr(mod, "end_criteria", base.end_criteria)),
+            thrust_sep=str(_read_attr(mod, "thrust_sep", base.thrust_sep)),
+            thrust_header=_read_attr(mod, "thrust_header", base.thrust_header),
+            pressure_sep=str(_read_attr(mod, "pressure_sep", base.pressure_sep)),
+            pressure_header=_read_attr(mod, "pressure_header", base.pressure_header),
         )
     return base
 

--- a/src/static_fire_toolkit/post_process/pressure_post_processing.py
+++ b/src/static_fire_toolkit/post_process/pressure_post_processing.py
@@ -605,8 +605,16 @@ if __name__ == "__main__":
         raise FileNotFoundError(error_msg)
 
     # Read and process data
-    pressure_data = pd.read_csv(pressure_data_file, sep=";", header=0)
-    thrust_data = pd.read_csv(thrust_data_file, sep="[, ]", header=0, engine="python")
+    from static_fire_toolkit.config_loader import load_global_config
+
+    cfg = load_global_config()
+    pressure_sep = str(getattr(cfg, "pressure_sep", ","))
+    pressure_header = getattr(cfg, "pressure_header", 0)
+    pressure_data = pd.read_csv(
+        pressure_data_file, sep=pressure_sep, header=pressure_header, engine="python"
+    )
+    # Processed thrust CSV is always saved with comma separator by toolkit
+    thrust_data = pd.read_csv(thrust_data_file)
     print("Successfully loaded input data files.")
 
     # Initialize processor and run processing steps

--- a/src/static_fire_toolkit/post_process/thrust_post_processing.py
+++ b/src/static_fire_toolkit/post_process/thrust_post_processing.py
@@ -707,9 +707,12 @@ if __name__ == "__main__":
         print(error_msg)
         raise FileNotFoundError(error_msg)
 
-    thrust_data = pd.read_csv(
-        data_file, sep="[,\t]", header=None, engine="python"
-    )  # 기존 데이터 형식과도 호환되도록 구분자로 쉼표(,) 및 탭(\t) 사용
+    from static_fire_toolkit.config_loader import load_global_config
+
+    cfg = load_global_config()
+    thrust_sep = str(getattr(cfg, "thrust_sep", ","))
+    thrust_header = getattr(cfg, "thrust_header", 0)
+    thrust_data = pd.read_csv(data_file, sep=thrust_sep, header=thrust_header)
     print("Successfully loaded input data file.")
 
     process = ThrustPostProcess(


### PR DESCRIPTION
## Summary
- `global_config`에 정의된 `thrust_sep`, `pressure_sep` 값을 사용해 raw 데이터 로딩 시 분리자를 설정할 수 있도록 함
  - 단일 문자 또는 정규식 표현 지원
  - 미지정 시 기본값으로 콤마(`,`) 사용
- `global_config`에 정의된 `thrust_header`, `pressure_header` 값을 사용해 raw 데이터 로딩 시 레이블 행을 설정할 수 있도록 함
  - 정수 값 또는 `None` 지원
  - 미지정 시 기본값으로 `0` 사용

## Checklist
- [x] CI passes (lint + tests)
- [ ] Docs/README updated (if behavior/user-facing changes)
- [x] Version bump planned if needed (release via tag `vX.Y.Z`)

## Notes
- 배경
  - 팀/장비별로 데이터 로거 출력 포맷이 상이해 구분자(`,`, `;`, `\t` 등)가 달라질 수 있음
  - 구분자를 모듈 내에 하드코딩하는 대신 설정 기반으로 제어함으로써 재현성과 다양한 데이터 형식에 대한 유연성, UX를 향상시키고자 함
- 변경 범위
  - 추력 raw 데이터: 구분자 기본값 `,` 유지, hearer 기본값 `None`에서 `0`으로 변경
  - 압력 raw 데이터: 구분자 기본값 `;`에서 `,`로 변경, header 기본값 `0` 유지
  - 출력 데이터 형식: 변경 없음
- 문서화
  - README/CHANGELOG는 릴리즈 직전 별도의 PR로 업데이트 예정
  - 후속 작업: CLI `--thrust-sep`, `--pressure-sep` 플래그 제공 검토