### PR TITLE
Release/docs and version finalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![HANARO SFT Logo](docs/logo-banner.png)
+![HANARO SFT Logo](https://raw.githubusercontent.com/snu-hanaro/static-fire-toolkit/refs/heads/main/docs/logo-banner.png)
 
 [![License - MIT](https://img.shields.io/github/license/snu-hanaro/static-fire-toolkit)](https://github.com/snu-hanaro/static-fire-toolkit/blob/main/LICENSE)
 [![PyPI Version](https://img.shields.io/pypi/v/static-fire-toolkit)](https://pypi.org/project/static-fire-toolkit/)
@@ -85,20 +85,20 @@ sft [--root <path>] burnrate [--expt <expt_file_name>]  # e.g. sft --root exampl
 Run `sft --help` and `sft [--root <path>] info` for more details.
 
 #### Examples from this repo:
-- Input samples: [examples/data/_thrust_raw/](examples/data/_thrust_raw/), [examples/data/_pressure_raw/](examples/data/_pressure_raw/), [examples/config.xlsx](examples/config.xlsx)
-- Output samples: [examples/results/thrust/](examples/results/thrust/), [examples/results/pressure/](examples/results/pressure/), [examples/results/burnrate/](examples/results/burnrate/)
+- Input samples: [`examples/data/_thrust_raw/`](https://github.com/snu-hanaro/static-fire-toolkit/tree/main/examples/data/_thrust_raw), [`examples/data/_pressure_raw/`](https://github.com/snu-hanaro/static-fire-toolkit/tree/main/examples/data/_pressure_raw/), [`examples/config.xlsx`](https://github.com/snu-hanaro/static-fire-toolkit/blob/main/examples/config.xlsx), [`examples/global_config.py`](https://github.com/snu-hanaro/static-fire-toolkit/blob/main/examples/global_config.py)
+- Output samples: [`examples/results/thrust/`](https://github.com/snu-hanaro/static-fire-toolkit/tree/main/examples/results/thrust), [`examples/results/pressure/`](https://github.com/snu-hanaro/static-fire-toolkit/tree/main/examples/results/pressure), [`examples/results/burnrate/`](https://github.com/snu-hanaro/static-fire-toolkit/tree/main/examples/results/burnrate)
 
 #### Output preview (from `examples/`):
 
-![Thrust Graph](./examples/results/thrust_graph/KNSB_250220_thrust.png)
+![Thrust Graph](https://raw.githubusercontent.com/snu-hanaro/static-fire-toolkit/refs/heads/main/examples/results/thrust_graph/KNSB_250220_thrust.png)
 
-![Pressure Graph](./examples/results/pressure_graph/KNSB_250220_pressure.png)
+![Pressure Graph](https://raw.githubusercontent.com/snu-hanaro/static-fire-toolkit/refs/heads/main/examples/results/pressure_graph/KNSB_250220_pressure.png)
 
-![Burnrate-Time Graph](./examples/results/burnrate_graph/Burnrate-Time/KNSB_250220_burnrate.png)
+![Burnrate-Time Graph](https://raw.githubusercontent.com/snu-hanaro/static-fire-toolkit/refs/heads/main/examples/results/burnrate_graph/Burnrate-Time/KNSB_250220_burnrate.png)
 
-![Burnrate-Pressure Graph](./examples/results/burnrate_graph/Burnrate-Pressure/KNSB_250220_burnrate.png)
+![Burnrate-Pressure Graph](https://raw.githubusercontent.com/snu-hanaro/static-fire-toolkit/refs/heads/main/examples/results/burnrate_graph/Burnrate-Pressure/KNSB_250220_burnrate.png)
 
-![Burnrate-Pressure Animation](./examples/results/burnrate_graph/Burnrate-Pressure/animation/KNSB_250220_burnrate_animation.gif)
+![Burnrate-Pressure Animation](https://raw.githubusercontent.com/snu-hanaro/static-fire-toolkit/refs/heads/main/examples/results/burnrate_graph/Burnrate-Pressure/animation/KNSB_250220_burnrate_animation.gif)
 
 ### Global Configuration: `global_config.py`
 
@@ -127,7 +127,7 @@ Optional parsing controls (fallbacks apply if unspecified):
 - thrust_header, pressure_header (header row index or None, default: `0`)
 - thrust_time_col_idx, thrust_col_idx, pressure_time_col_idx, pressure_col_idx
 
-[Example](examples/global_config.py):
+[Example](https://github.com/snu-hanaro/static-fire-toolkit/blob/main/examples/global_config.py):
 
 ```python
 # ------------ Load Cell (Required) ------------
@@ -315,7 +315,7 @@ pytest -q
 
 ### CI/CD Strategy
 - Branching: trunk-based development (main protected)
-- Matrix testing: Python 3.10–3.13, both latest and [minimum dependencies](constraints-min.txt)
+- Matrix testing: Python 3.10–3.13, both latest and [minimum dependencies](https://github.com/snu-hanaro/static-fire-toolkit/blob/main/constraints-min.txt)
 - Tags:
   - Signed tags by default
   - Annotated tags allowed with --no-sign
@@ -334,4 +334,4 @@ Please use Issues/PRs with templates. Recommended:
 
 ## License
 
-This project is licensed under the [MIT License](/LICENSE).
+This project is licensed under the [MIT License](https://github.com/snu-hanaro/static-fire-toolkit/blob/main/LICENSE).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,163 @@
-## [0.1.0] - 2025-09-15
+# Changelog
 
-- Initial release
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2025-09-19
+
+### Added
+
+- **Initial public release on PyPI**
+- CLI entry point provided: the script can now be executed globally via `sft` command
+
+### Changed
+
+- **Project is now open source under the MIT License — contributions are welcome!**
+
+- **Breaking:** Update default data I/O directory structure
+  - **Input**
+    - was: `_pressure_raw/`, `_thrust_raw/`
+    - now: `data/_pressure_raw/`, `data/_thrust_raw/`
+  - **Output**
+    - was:  
+      - `burnrate_calc/burnrate/`  
+      - `burnrate_calc/burnrate_graph/`  
+      - `pressure_graph/`  
+      - `pressure_post_process/`  
+      - `thrust_graph/`  
+      - `thrust_post_process/`
+    - now:  
+      - `results/burnrate/`  
+      - `results/burnrate_graph/`  
+      - `results/pressure/`  
+      - `results/pressure_graph/`  
+      - `results/thrust/`  
+      - `results/thrust_graph/`
+
+- **Breaking:** Rename `config.py` to `global_config.py` to clearly distinguish it from `config.xlsx`
+
+- **Breaking:** Add new configuration options in `global_config` to control raw data parsing:  
+  - `thrust_sep`, `pressure_sep`: CSV delimiters  
+  - `thrust_header`, `pressure_header`: header row indices
+
+- **Breaking:** Raw thrust/pressure data parsing no longer relies on hardcoded column names/indices.  
+  Instead, `global_config` now provides:  
+  - `thrust_time_col_idx`, `thrust_col_idx`  
+  - `pressure_time_col_idx`, `pressure_col_idx`
+
+- **Breaking:** `global_config` requires explicit load cell parameters for voltage → thrust conversion:  
+  - `sensitivity_mv_per_v` (replaces `rated_output`)  
+  - `rated_capacity_kgf` (replaces `rated_load`)  
+  - `gain_internal_resistance_kohm`  
+  - `gain_offset`  
+
+  Missing values will now raise an explicit error. Load cell constants previously hardcoded are now fully parameterized, making the package usable as a public library rather than team-internal only.
+
+- `config.xlsx`: Rename variable `expt_input_voltage [V]` → `expt_excitation_voltage [V]`  
+  (legacy alias maintained for backward compatibility)
+
+- Adjust thrust/pressure graph output formatting
+
+### Fixed
+- Fixed an issue where `global_config.py` (formerly `config.py`) was not loaded correctly when the tool was executed from certain directories.
+
+### Development
+
+- Migrate to Git-based version control
+- Adopt ruff as linter and formatter
+- Add project-level Cursor rule sets, ensuring consistency when using AI-based tools like Cursor IDE
+
+## 0.6.0 - 2025-04-06
+Updated by Yunseo Kim (yunseo@snu.ac.kr)
+
+### Added
+
+- Add hash-based detection of new/modified files
+- Add batch processing feature with tqdm progress bars
+
+### Changed
+
+- Refactor code for better organization and maintainability
+
+## 0.5.0 - 2025-03-06
+
+Updated by Yunseo Kim (yunseo@snu.ac.kr)
+
+### Added
+
+- Add more detailed logging of peak detection for debugging
+- Add fallback width value(20) for too small peak widths (< 1.0)
+- Add logging of max thrust value and its index
+- Add logging of basic statistics (max, min, mean, std) for pressure raw data before processing
+- Add logging of maximum pressure value and its index after shifting
+
+### Changed
+
+- Improve the baseline estimation process
+- Prevent negative thrust values
+
+## 0.4.0 - 2025-02-17
+
+Updated by Yunseo Kim (yunseo@snu.ac.kr)
+
+### Added
+
+- Add data validation and warning messages to the burn rate analyzer
+- Improve error handling and logging throughout
+- Add type hints and detailed docstrings to the burn rate analyzer
+
+### Changed
+
+- Refactor burn rate analyzer to object-oriented interface with BurnRateAnalyzer class
+- Encapsulate the logger within the class
+
+### Fixed
+- To avoid file I/O errors based on the execution environment or current working directory, set the file paths to absolute paths using the OS module
+
+## 0.3.0 - 2025-02-08
+
+Updated by Yunseo Kim (yunseo@snu.ac.kr)
+
+### Added
+
+- Add type hints and detailed docstrings
+- Improve error handling and logging throughout
+- Add data validation and warning messages
+  - Checks for duplicate or non-increasing timestamps and logs warnings
+  - Detection for missing or invalid key data
+
+### Fixed
+
+- Check and resolve the part where the deprecation warnings were occurring
+
+## 0.2.0 - 2025-01-22
+
+Updated by Yunseo Kim (yunseo@snu.ac.kr)
+
+### Added
+
+- Add support for the new DAQ's data format
+- Add burn rate determination feature
+
+### Changed
+
+- Improve the interpolation algorithm from CubicSpline to PCHIP
+- Change output format from .txt(sep=' ') to .csv(sep=',')
+- Separate items that vary per test into a config.xlsx file distinct from config.py
+
+## 0.1.0 - 2024-06-18
+
+First written by Jiwan Seo (jiwan0216@snu.ac.kr, Project Manager of Hanaro)
+
+### Added
+
+- Initial implementation of basic post-processing for static-fire test data
+- Support parsing raw thrust and chamber pressure data
+- Export processed results to CSV/graph outputs
+
+[unreleased]: https://github.com/snu-hanaro/static-fire-toolkit/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/snu-hanaro/static-fire-toolkit/releases/tag/v1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "static-fire-toolkit"
-version = "0.1.0"
-description = "Static-fire test data processing toolkit"
+version = "1.0.0"
+description = "Command-line toolkit for static-fire test data processing and analysis"
 readme = "README.md"
 requires-python = ">=3.10"
 
@@ -54,7 +54,7 @@ sft = "static_fire_toolkit.cli:main"
 [project.urls]
 Homepage = "https://github.com/snu-hanaro/static-fire-toolkit"
 Source = "https://github.com/snu-hanaro/static-fire-toolkit"
-Changelog = "https://github.com/snu-hanaro/static-fire-toolkit/docs/CHANGELOG.md"
+Changelog = "https://github.com/snu-hanaro/static-fire-toolkit/blob/main/docs/CHANGELOG.md"
 Issues = "https://github.com/snu-hanaro/static-fire-toolkit/issues"
 "Release Notes" = "https://github.com/snu-hanaro/static-fire-toolkit/releases"
 "About HANARO" = "https://hanaro.snu.ac.kr/"


### PR DESCRIPTION
## Summary
- 릴리즈 문서/메타데이터 최종 정리
  - README의 상대 경로를 PyPI 렌더링 호환을 위해 GitHub 절대 경로로 수정
  - pyproject.toml 설명문을 다듬고, 버전을 1.0.0으로 상승
  - CHANGELOG v1.0.0 최종 확정(변경 사항, 하위호환/주요 포인트 정리)

## Checklist
- [x] CI passes (lint + tests)
- [x] Docs/README updated (if behavior/user-facing changes)
- [x] Version bump planned if needed (release via tag `vX.Y.Z`)

## Notes
- 목적: PyPI 페이지에서 이미지/링크가 정상 노출되도록 보장하고, 릴리즈 노트/버전 메타정보를 릴리즈 직전 상태로 확정
- TestPyPI를 통해 배포 테스트 후에, 문제 없으면 태그 v1.0.0을 생성하고 배포 워크플로우를 실행할 것 (PyPI 퍼블리시)
