### PR TITLE
chore(release): bump version and update changelog for hotfix 1.0.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2025-09-20
+
+### Fixed
+- Correct `__version__` definition in `src/__init__.py` to dynamically read from package metadata.  
+  This ensures consistency between `pyproject.toml` and runtime `__version__`, preventing version mismatches in future releases.
+- Fix broken PyPI download badge in `README.md` (remove deprecated `pypi/dm` badge)
+
 ## [1.0.0] - 2025-09-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "static-fire-toolkit"
-version = "1.0.0"
+version = "1.0.1"
 description = "Command-line toolkit for static-fire test data processing and analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/static_fire_toolkit/__init__.py
+++ b/src/static_fire_toolkit/__init__.py
@@ -1,4 +1,10 @@
 """Static-Fire Toolkit core package."""
 
 __all__ = ["__version__"]
-__version__ = "0.1.0"
+
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("static-fire-toolkit")  # pyproject의 project.name
+except PackageNotFoundError:  # editable 설치 등 특수 상황 대비
+    __version__ = "0+unknown"


### PR DESCRIPTION
- `pyproject.toml`: update version metadata
- `__init__.py`: sync `__version__`
- CHANGELOG: add 1.0.1 notes

## Summary
- 1.0.1 핫픽스 릴리즈 메타 정리
  - `pyproject.toml` 버전을 1.0.1로 업데이트
  - 패키지 `__version__` 동기화(`src/static_fire_toolkit/__init__.py`)
  - CHANGELOG에 v1.0.1 항목 추가(핫픽스 노트)

## Checklist
- [x] CI passes (lint + tests)
- [x] Docs/README updated (if behavior/user-facing changes)
- [x] Version bump planned if needed (release via tag `v1.0.1`)

## Notes
- `src/__init__.py` 내 `__version__` 정보가 업데이트되지 않아 0.1.0으로 잘못 표기되는 오류를 수정하기 위한 패치
- 패키지 정보를 동적으로 불러오도록 함으로써 동일 문제 재발 방지
- 이외에 기능상 변경 없음
