### PR TITLE
docs: Add Specs & Issue Tracking section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,18 @@ It compensates for the difference between local atmospheric pressure at test tim
 
 ## Development
 
+### Specs & Issue Tracking
+
+This project is document-first.
+
+Authoritative project records live under:
+- docs/context
+- docs/log
+- docs/work
+- docs/specs
+
+Do not treat these as auxiliary documentation.
+
 ### Tools used
 - Ruff: linting & formatting
 - pytest: testing


### PR DESCRIPTION
## Summary
- **[A-006]** Add "Specs & Issue Tracking" subsection under `## Development` in README
- Points contributors and agents to `docs/context`, `docs/log`, `docs/work`, `docs/specs`

## Commits
1. `[A-006] docs: add Specs & Issue Tracking section to README`

## Notes
- Touches `README.md` (Development section only). `docs/img-restructure` also touches README (logo path line) — different sections, no conflict expected.